### PR TITLE
Support more framework versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-A library of C# core components that enhance the standard library. Supports .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0.
+A library of C# core components that enhance the standard library. Supports .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0.
 
 * Source code: <https://github.com/danylofitel/LibSharp>.
 * NuGet package: <https://www.nuget.org/packages/LibSharp>.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,291 @@
 
 ## Introduction
 
-A library of C# core components that enhance the standard library.
+A library of C# core components that enhance the standard library. Supports .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0.
 
-Source code: <https://github.com/danylofitel/LibSharp>.
-NuGet package: <https://www.nuget.org/packages/LibSharp>.
+* Source code: <https://github.com/danylofitel/LibSharp>.
+* NuGet package: <https://www.nuget.org/packages/LibSharp>.
 
-## Components
+LibSharp consists of the following namespaces:
 
 * Common - contains extension methods for standard .NET types, as well commonly used utilities.
-* Caching - contains classes that enable caching in-memory with custom time-to-live. Both synchronous and asynchronous versions are available.
-* Collections - contains extension methods for standard .NET collections, as well as additional collection types.
+* Collections - contains extension methods for standard .NET library collections, as well as additional collection types.
+* Caching - contains classes that enable in-memory value caching with custom time-to-live. Both synchronous and asynchronous versions are available.
+
+## Components and Usage
+
+### Common
+
+`Common` namespace contains the static class `Argument` for convenient validation of public function arguments, plus extension methods and utilities for built-in types like `string` and `DateTime`.
+
+```csharp
+    using LibSharp.Common;
+
+    public static void CommonExamples(string stringParam, long longParam, object objectParam)
+    {
+        // Argument validation
+        Argument.EqualTo(stringParam, "Hello world", nameof(stringParam));
+        Argument.NotEqualTo(stringParam, "Hello", nameof(stringParam));
+
+        Argument.GreaterThan(longParam, -1L, nameof(longParam));
+        Argument.GreaterThanOrEqualTo(longParam, 0L, nameof(longParam));
+        Argument.LessThan(longParam, 100L, nameof(longParam));
+        Argument.LessThanOrEqualTo(longParam, 99L, nameof(longParam));
+
+        Argument.NotNull(stringParam, nameof(stringParam));
+        Argument.NotNullOrEmpty(stringParam, nameof(stringParam));
+        Argument.IsNullOrWhiteSpace(stringParam, nameof(stringParam));
+
+        Argument.OfType(objectParam, typeof(List<string>), nameof(objectParam));
+
+        // DateTime extensions
+        DateTime fromEpochMilliseconds = longParam.FromEpochMilliseconds();
+        DateTime fromEpochSeconds = longParam.FromEpochSeconds();
+        long epochMilliseconds = DateTime.UtcNow.ToEpochMilliseconds();
+        long epochSeconds = DateTime.UtcNow.ToEpochSeconds();
+
+        // String extensions
+        string base64Encoded = stringParam.Base64Encode();
+        string base64Decoded = base64Encoded.Base64Decode();
+
+        string reversed = stringParam.Reverse();
+        string truncated = stringParam.Truncate(10);
+
+        // Type extensions
+        IComparer<int> intComparer = TypeExtensions.GetDefaultComparer<int>();
+
+        // XML serialization extensions
+        string serializedToXml = objectParam.SerializeToXml();
+        List<string> deserializedFromXml = serializedToXml.DeserializeFromXml<List<string>>();
+    }
+```
+
+### Collections
+
+`Collections` namespace contains various extension methods for `ICollection`, `IDictionary`, `IEnumerable` interfaces plus `MinPriorityQueue` and `MaxPriorityQueue` collections.
+
+```csharp
+    using LibSharp.Collections;
+
+    public static void CollectionsExamples()
+    {
+        // ICollection extensions
+        ICollection<int> collection = new List<int>();  // []
+        collection.AddRange(Enumerable.Range(0, 10));   // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        // IDictionary extensions
+        IDictionary<string, string> dictionary = new Dictionary<string, string>();
+
+        _ = dictionary.AddOrUpdate(
+            "key",
+            "addedValue",
+            (key, existingValue) => "updatedValue");
+
+        _ = dictionary.AddOrUpdate(
+            "key",
+            key => "addedValue",
+            (key, existingValue) => "updatedValue");
+
+        _ = dictionary.AddOrUpdate(
+            "key",
+            (key, argument) => "addedValue" + argument,
+            (key, existingValue, argument) => "updatedValue" + argument,
+            "argument");
+
+        _ = dictionary.GetOrAdd(
+            "key",
+            "addedValue");
+
+        _ = dictionary.GetOrAdd(
+            "key",
+            keyValue => "addedValue");
+
+        _ = dictionary.GetOrAdd(
+            "key",
+            (keyValue, argument) => "addedValue" + argument,
+            "argument");
+        
+        IDictionary<string, string> newCopy = dictionary.Copy();
+
+        IDictionary<string, string> destination = new Dictionary<string, string>();
+        IDictionary<string, string> result = dictionary.CopyTo(destination);
+
+        // IEnumerable extensions
+        IEnumerable<List<int>> chunks = Enumerable.Range(0, 10).Chunk(10, item => item).ToList();   // [ [0, 1, 2, 3, 4, 5], [6, 7], [8, 9] ]
+
+        IEnumerable<int> enumerable = Enumerable.Range(100).Concat(Enumerable.Range(100)).ToList();
+        int firstIndex = enumerable.FirstIndexOf(51);
+        int lastIndex = enumerable.LastIndexOf(51);
+
+        IEnumerable<int> shuffled = enumerable.Shuffle();
+
+        // Min priority queue
+        MinPriorityQueue<int> minPq = new MinPriorityQueue<int>();
+        minPq.Enqueue(2);
+        minPq.Enqueue(1);
+        minPq.Enqueue(3);
+
+        _ = minPq.Dequeue();    // 1
+        _ = minPq.Dequeue();    // 2
+        _ = minPq.Dequeue();    // 3
+
+        // Max priority queue
+        MinPriorityQueue<int> maxPq = new MinPriorityQueue<int>();
+        maxPq.Enqueue(2);
+        maxPq.Enqueue(1);
+        maxPq.Enqueue(3);
+
+        _ = maxPq.Dequeue();    // 3
+        _ = maxPq.Dequeue();    // 2
+        _ = maxPq.Dequeue();    // 1
+    }
+```
+
+### Caching
+
+`Caching` namespace contains a number of classes for thread-safe lazy initialization and caching of in-memory values.
+
+Notes:
+
+* Some of the classes implement `IDisposable` interface and should be correctly disposed.
+* Be cautious when caching types that implement `IDisposable` interface as the values will not be automatically disposed by the caches.
+* Be cautious when using classes with `LazyThreadSafetyMode.PublicationOnly` behavior together with `IDisposable` types as discarded instances will not be disposed.
+
+#### Lazy
+
+Two different implementations of async lazy values are available - `LazyAsyncPublicationOnly` and `LazyAsyncExecutionAndPublication`. Those are async versions of `System.Lazy` class with `LazyThreadSafetyMode.PublicationOnly` and `LazyThreadSafetyMode.ExecutionAndPublication` modes respectively. The reason that async lazy implementations are separate classes is that `LazyAsyncExecutionAndPublication` implements `IDisposable` due to its usage of an instance of `SemaphoreSlim` whereas `LazyAsyncPublicationOnly` does not need to implement `IDisposable`.
+
+```csharp
+    using LibSharp.Caching;
+
+    public static async Task LazyAsyncPublicationOnlyExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        LazyAsyncPublicationOnly<int> lazy = new LazyAsyncPublicationOnly<int>(factory);
+
+        bool hasValue = lazy.HasValue;                              // false
+        int value = await lazy.GetValueAsync(cancellationToken);    // factory invoked
+        hasValue = lazy.HasValue;                                   // true
+        value = await lazy.GetValueAsync(cancellationToken);        // factory not invoked
+        hasValue = lazy.HasValue;                                   // true
+    }
+
+    public static async Task LazyAsyncExecutionAndPublicationExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        using LazyAsyncExecutionAndPublication<int> lazy = new LazyAsyncExecutionAndPublication<int>(factory);
+
+        bool hasValue = lazy.HasValue;                              // false
+        int value = await lazy.GetValueAsync(cancellationToken);    // factory invoked
+        hasValue = lazy.HasValue;                                   // true
+        value = await lazy.GetValueAsync(cancellationToken);        // factory not invoked
+        hasValue = lazy.HasValue;                                   // true
+    }
+```
+
+#### Initializers
+
+Initializers in LibSharp are equivalents of lazy types, with the only difference being that the value factory is provided at lazy initialization time instead of creation time. They also enable cases where different factories can be used to initialize the value, where only one will succeed at setting the value.
+
+```csharp
+    using LibSharp.Caching;
+
+    public static void InitializerExample(Func<int> factory)
+    {
+        Initializer<int> initializer = new Initializer<int>();
+
+        bool hasValue = initializer.HasValue;       // false
+        int value = initializer.GetValue(factory);  // factory invoked
+        hasValue = initializer.HasValue;            // true
+        value = initializer.GetValue(factory);      // factory not invoked
+        hasValue = initializer.HasValue;            // true
+    }
+
+    public static async Task InitializerAsyncPublicationOnlyExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        InitializerAsyncPublicationOnly<int> initializer = new InitializerAsyncPublicationOnly<int>();
+
+        bool hasValue = initializer.HasValue;                                       // false
+        int value = await initializer.GetValueAsync(factory, cancellationToken);    // factory invoked
+        hasValue = initializer.HasValue;                                            // true
+        value = await initializer.GetValueAsync(factory, cancellationToken);        // factory not invoked
+        hasValue = initializer.HasValue;                                            // true
+    }
+
+    public static async Task InitializerAsyncExecutionAndPublicationExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        using InitializerAsyncExecutionAndPublication<int> initializer = new InitializerAsyncExecutionAndPublication<int>();
+
+        bool hasValue = initializer.HasValue;                                       // false
+        int value = await initializer.GetValueAsync(factory, cancellationToken);    // factory invoked
+        hasValue = initializer.HasValue;                                            // true
+        value = await initializer.GetValueAsync(factory, cancellationToken);        // factory not invoked
+        hasValue = initializer.HasValue;                                            // true
+    }
+```
+
+#### Value Caches
+
+Value caches are lazy types that automatically refresh the value when it expires. It is possible to either provide an exact time-to-live value or a custom function to determine expiration of a value (useful, for example, for in-memory caching of tokens with known expiration time). It is also possible to provide either a factory method for creation of a new value or a factory for updating the existing value.
+
+Note that `ValueCacheAsync` guarantees `LazyThreadSafetyMode.ExecutionAndPublication` behavior and implements `LazyThreadSafetyMode.ExecutionAndPublication`.
+
+```csharp
+    using LibSharp.Caching;
+
+    public static void ValueCacheExample(Func<int> factory)
+    {
+        ValueCache<int> cache = new ValueCache<int>(factory, TimeSpan.FromMilliseconds(1));
+
+        bool hasValue = cache.HasValue; // false
+        int value = cache.GetValue();   // factory invoked
+        hasValue = cache.HasValue;      // true
+
+        Thread.Sleep(10);
+        value = cache.GetValue();       // factory invoked
+        hasValue = cache.HasValue;      // true
+    }
+
+    public static async Task ValueCacheAsyncExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        using ValueCacheAsync<int> cache = new ValueCacheAsync<int>(factory, TimeSpan.FromMilliseconds(1));
+
+        bool hasValue = cache.HasValue;                                     // false
+        int value = await cache.GetValueAsync(factory, cancellationToken);  // factory invoked
+        hasValue = cache.HasValue;                                          // true
+
+        await Task.Delay(10);
+        value = await cache.GetValueAsync(factory, cancellationToken);      // factory invoked
+        hasValue = cache.HasValue;                                          // true
+    }
+```
+
+#### Key-Value Caches
+
+Key-value caches allow to cache and automatically refresh multiple values within a single data structure.
+
+```csharp
+    using LibSharp.Caching;
+
+    public static void KeyValueCacheExample(Func<string, int> factory)
+    {
+        KeyValueCache<string, int> cache = new KeyValueCache<string, int>(factory, TimeSpan.FromMinutes(1));
+
+        int valueA = cache.GetValue("a");   // factory invoked for "a"
+        int valueB = cache.GetValue("b");   // factory invoked for "b"
+
+        valueA = cache.GetValue("a");       // factory not invoked
+        valueB = cache.GetValue("b");       // factory not invoked
+    }
+
+    public static async Task KeyValueCacheAsyncExample(Func<string, CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        using KeyValueCacheAsync<string, int> cache = new KeyValueCacheAsync<string, int>(factory, TimeSpan.FromMinutes(1));
+
+        KeyValueCache<string, int> cache = new KeyValueCache<string, int>(factory, TimeSpan.FromMinutes(1));
+
+        int valueA = await cache.GetValueAsync("a", cancellationToken); // factory invoked for "a"
+        int valueB = await cache.GetValueAsync("b", cancellationToken); // factory invoked for "b"
+
+        valueA = await cache.GetValueAsync("a", cancellationToken);     // factory not invoked
+        valueB = await cache.GetValueAsync("b", cancellationToken);     // factory not invoked
+    }
+```

--- a/src/LibSharp/Caching/KeyValueCacheAsync.cs
+++ b/src/LibSharp/Caching/KeyValueCacheAsync.cs
@@ -35,7 +35,10 @@ namespace LibSharp.Caching
         {
             Argument.NotNull(key, nameof(key));
 
-            ObjectDisposedException.ThrowIf(m_isDisposed, this);
+            if (m_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
 
             /* ValueCacheAsync is disposable, so we should to call Dispose() on every created instance.
              *

--- a/src/LibSharp/Caching/ValueCacheAsync.cs
+++ b/src/LibSharp/Caching/ValueCacheAsync.cs
@@ -82,7 +82,10 @@ namespace LibSharp.Caching
         {
             get
             {
-                ObjectDisposedException.ThrowIf(m_isDisposed, this);
+                if (m_isDisposed)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
 
                 return m_boxed != null;
             }
@@ -93,7 +96,10 @@ namespace LibSharp.Caching
         {
             get
             {
-                ObjectDisposedException.ThrowIf(m_isDisposed, this);
+                if (m_isDisposed)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
 
                 return m_boxed?.Expiration;
             }
@@ -102,7 +108,10 @@ namespace LibSharp.Caching
         /// <inheritdoc/>
         public async Task<T> GetValueAsync(CancellationToken cancellationToken = default)
         {
-            ObjectDisposedException.ThrowIf(m_isDisposed, this);
+            if (m_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
 
             if (m_boxed == null || DateTime.UtcNow >= m_boxed.Expiration)
             {

--- a/src/LibSharp/Common/DateTimeExtensions.cs
+++ b/src/LibSharp/Common/DateTimeExtensions.cs
@@ -10,13 +10,19 @@ namespace LibSharp.Common
     public static class DateTimeExtensions
     {
         /// <summary>
+        /// The value of this constant is equivalent to 00:00:00.0000000 UTC, January 1, 1970, in the Gregorian calendar.
+        /// UnixEpoch defines the point in time when Unix time is equal to 0.
+        /// </summary>
+        public static DateTime UnixEpoch { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
         /// Creates a DateTime from Epoch milliseconds.
         /// </summary>
         /// <param name="epochMilliseconds">Epoch milliseconds.</param>
         /// <returns>A DateTime value.</returns>
         public static DateTime FromEpochMilliseconds(this long epochMilliseconds)
         {
-            return DateTime.UnixEpoch.AddMilliseconds(epochMilliseconds);
+            return UnixEpoch.AddMilliseconds(epochMilliseconds);
         }
 
         /// <summary>
@@ -26,7 +32,7 @@ namespace LibSharp.Common
         /// <returns>A DateTime value.</returns>
         public static DateTime FromEpochSeconds(this long epochSeconds)
         {
-            return DateTime.UnixEpoch.AddSeconds(epochSeconds);
+            return UnixEpoch.AddSeconds(epochSeconds);
         }
 
         /// <summary>
@@ -36,7 +42,7 @@ namespace LibSharp.Common
         /// <returns>Epoch milliseconds.</returns>
         public static long ToEpochMilliseconds(this DateTime dateTime)
         {
-            TimeSpan epochTimeSpan = dateTime.Subtract(DateTime.UnixEpoch);
+            TimeSpan epochTimeSpan = dateTime.Subtract(UnixEpoch);
             return Convert.ToInt64(epochTimeSpan.TotalMilliseconds);
         }
 
@@ -47,7 +53,7 @@ namespace LibSharp.Common
         /// <returns>Epoch seconds.</returns>
         public static long ToEpochSeconds(this DateTime dateTime)
         {
-            TimeSpan epochTimeSpan = dateTime.Subtract(DateTime.UnixEpoch);
+            TimeSpan epochTimeSpan = dateTime.Subtract(UnixEpoch);
             return Convert.ToInt64(epochTimeSpan.TotalSeconds);
         }
     }

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>LibSharp</AssemblyName>
@@ -24,6 +24,7 @@
         - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
+        1.1.0: Add support for .NET Standard 2.1, .NET 5.0, .NET 6.0 and .NET 7.0, update documentation.
         1.0.0: Initial release.
     </PackageReleaseNotes>
     <PackageTags>LibSharp;Async;Lazy;Cache;Caching;Collections;Extensions</PackageTags>
@@ -35,8 +36,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath=""/>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath=""/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>LibSharp</AssemblyName>
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <PackageId>LibSharp</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Danylo Fitel</Authors>
     <Copyright>Copyright (c) Danylo Fitel 2024</Copyright>
     <Description>
@@ -24,8 +24,8 @@
         - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
-        1.1.0: Add support for .NET Standard 2.1, .NET 5.0, .NET 6.0 and .NET 7.0, update documentation.
-        1.0.0: Initial release.
+        1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
+        1.0.0: Initial release. Supports .NET 8.0 only.
     </PackageReleaseNotes>
     <PackageTags>LibSharp;Async;Lazy;Cache;Caching;Collections;Extensions</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -975,7 +974,7 @@ namespace LibSharp.Collections.UnitTests
 
         private class WrapperClassComparer : IComparer<WrapperClass>
         {
-            public int Compare([AllowNull] WrapperClass x, [AllowNull] WrapperClass y)
+            public int Compare(WrapperClass x, WrapperClass y)
             {
                 return x.Value.CompareTo(y.Value);
             }
@@ -988,7 +987,7 @@ namespace LibSharp.Collections.UnitTests
 
         private class WrapperStructComparer : IComparer<WrapperStruct>
         {
-            public int Compare([AllowNull] WrapperStruct x, [AllowNull] WrapperStruct y)
+            public int Compare(WrapperStruct x, WrapperStruct y)
             {
                 return x.Value.CompareTo(y.Value);
             }

--- a/test/LibSharp.UnitTests/Collections/MinPriorityQueueUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/MinPriorityQueueUnitTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -975,7 +974,7 @@ namespace LibSharp.Collections.UnitTests
 
         private class WrapperClassComparer : IComparer<WrapperClass>
         {
-            public int Compare([AllowNull] WrapperClass x, [AllowNull] WrapperClass y)
+            public int Compare(WrapperClass x, WrapperClass y)
             {
                 return x.Value.CompareTo(y.Value);
             }
@@ -988,7 +987,7 @@ namespace LibSharp.Collections.UnitTests
 
         private class WrapperStructComparer : IComparer<WrapperStruct>
         {
-            public int Compare([AllowNull] WrapperStruct x, [AllowNull] WrapperStruct y)
+            public int Compare(WrapperStruct x, WrapperStruct y)
             {
                 return x.Value.CompareTo(y.Value);
             }

--- a/test/LibSharp.UnitTests/Common/ArgumentUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/ArgumentUnitTests.cs
@@ -46,7 +46,7 @@ namespace LibSharp.UnitTests.Common
             Argument.EqualTo(double.Epsilon, double.Epsilon, "name");
             Argument.EqualTo('c', 'c', "name");
             Argument.EqualTo("value", "value", "name");
-            Argument.EqualTo(DateTime.UnixEpoch, DateTime.UnixEpoch, "name");
+            Argument.EqualTo(DateTimeExtensions.UnixEpoch, DateTimeExtensions.UnixEpoch, "name");
             Argument.EqualTo(Guid.Empty, Guid.Empty, "name");
             Argument.EqualTo(this, this, "name");
         }

--- a/test/LibSharp.UnitTests/Common/BoxUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/BoxUnitTests.cs
@@ -34,11 +34,11 @@ namespace LibSharp.UnitTests.Common
         public void ValueType_FromValue()
         {
             // Arrange
-            Box<DateTime> box = new Box<DateTime>(DateTime.UnixEpoch);
+            Box<DateTime> box = new Box<DateTime>(DateTimeExtensions.UnixEpoch);
 
             // Assert
             Assert.IsTrue(box.HasValue);
-            Assert.AreEqual(DateTime.UnixEpoch, box.Value);
+            Assert.AreEqual(DateTimeExtensions.UnixEpoch, box.Value);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace LibSharp.UnitTests.Common
             // Assert
             Assert.IsFalse(box.Equals((object)null));
             Assert.IsFalse(box.Equals(1));
-            Assert.IsFalse(box.Equals(DateTime.UnixEpoch));
+            Assert.IsFalse(box.Equals(DateTimeExtensions.UnixEpoch));
             Assert.IsFalse(box.Equals(new Box<object>(new object())));
             Assert.IsFalse(box.Equals(new Box<object>("boxed")));
             Assert.IsFalse(box.Equals((object)"boxed"));
@@ -163,7 +163,7 @@ namespace LibSharp.UnitTests.Common
             // Assert
             Assert.IsFalse(box.Equals((object)null));
             Assert.IsFalse(box.Equals(1));
-            Assert.IsFalse(box.Equals(DateTime.UnixEpoch));
+            Assert.IsFalse(box.Equals(DateTimeExtensions.UnixEpoch));
             Assert.IsFalse(box.Equals(new Box<object>(new object())));
             Assert.IsFalse(box.Equals(new Box<object>("boxed")));
 

--- a/test/LibSharp.UnitTests/Common/DateTimeExtensionsUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/DateTimeExtensionsUnitTests.cs
@@ -13,7 +13,7 @@ namespace LibSharp.UnitTests.Common
         public void FromEpochMilliseconds()
         {
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
-            long millisecondsSinceEpoch = (long)currentDate.Subtract(DateTime.UnixEpoch).TotalMilliseconds;
+            long millisecondsSinceEpoch = (long)currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalMilliseconds;
             DateTime convertedDateTime = millisecondsSinceEpoch.FromEpochMilliseconds();
 
             Assert.AreEqual(currentDate.Date, convertedDateTime.Date);
@@ -25,7 +25,7 @@ namespace LibSharp.UnitTests.Common
         public void FromEpochSeconds()
         {
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
-            long secondsSinceEpoch = (long)currentDate.Subtract(DateTime.UnixEpoch).TotalSeconds;
+            long secondsSinceEpoch = (long)currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalSeconds;
             DateTime convertedDateTime = secondsSinceEpoch.FromEpochSeconds();
 
             Assert.AreEqual(currentDate.Date, convertedDateTime.Date);
@@ -36,7 +36,7 @@ namespace LibSharp.UnitTests.Common
         [TestMethod]
         public void ToEpochMilliseconds()
         {
-            long fromEpoch = DateTime.UnixEpoch.ToEpochMilliseconds();
+            long fromEpoch = DateTimeExtensions.UnixEpoch.ToEpochMilliseconds();
             Assert.AreEqual(0, fromEpoch);
 
             long fromDayAfterEpoch = new DateTime(1970, 1, 2).ToEpochMilliseconds();
@@ -44,22 +44,22 @@ namespace LibSharp.UnitTests.Common
 
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
             currentDate = currentDate.AddMilliseconds(-currentDate.Millisecond);
-            long millisecondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
+            long millisecondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalMilliseconds);
             Assert.AreEqual(currentDate.ToEpochMilliseconds(), millisecondsSinceEpoch);
         }
 
         [TestMethod]
         public void ToEpochSeconds()
         {
-            long fromEpoch = DateTime.UnixEpoch.ToEpochSeconds();
+            long fromEpoch = DateTimeExtensions.UnixEpoch.ToEpochSeconds();
             Assert.AreEqual(0, fromEpoch);
 
-            long fromDayAfterEpoch = DateTime.UnixEpoch.AddDays(1).ToEpochSeconds();
+            long fromDayAfterEpoch = DateTimeExtensions.UnixEpoch.AddDays(1).ToEpochSeconds();
             Assert.AreEqual(24 * 60 * 60, fromDayAfterEpoch);
 
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
             currentDate = currentDate.AddMilliseconds(-currentDate.Millisecond);
-            long secondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTime.UnixEpoch).TotalSeconds);
+            long secondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalSeconds);
             Assert.AreEqual(currentDate.ToEpochSeconds(), secondsSinceEpoch);
         }
     }

--- a/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
+++ b/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>LibSharp.UnitTests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
+++ b/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>LibSharp.UnitTests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Add support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0.
Update and expand documentation.