### PR TITLE
1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 bin/
 obj/
 TestResults/
+coveragereport/
 *.user

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ LibSharp consists of the following namespaces:
         IDictionary<string, string> result = dictionary.CopyTo(destination);
 
         // IEnumerable extensions
-        IEnumerable<List<int>> chunks = Enumerable.Range(0, 10).Chunk(10, item => item).ToList();   // [ [0, 1, 2, 3, 4, 5], [6, 7], [8, 9] ]
+        List<List<int>> chunks = Enumerable.Range(0, 10).Chunk(20, item => item).ToList();  // [ [0, 1, 2, 3, 4, 5], [6, 7], [8, 9] ]
 
         IEnumerable<int> enumerable = Enumerable.Range(100).Concat(Enumerable.Range(100)).ToList();
         int firstIndex = enumerable.FirstIndexOf(51);
         int lastIndex = enumerable.LastIndexOf(51);
 
-        IEnumerable<int> shuffled = enumerable.Shuffle();
+        int[] shuffled = enumerable.Shuffle();
 
         // Min priority queue
         MinPriorityQueue<int> minPq = new MinPriorityQueue<int>();

--- a/src/LibSharp/Caching/KeyValueCacheAsync.cs
+++ b/src/LibSharp/Caching/KeyValueCacheAsync.cs
@@ -47,7 +47,7 @@ namespace LibSharp.Caching
              *
              * Those additional instances will not be disposed of if they implement IDisposable.
              *
-             * Wrapping individual value caches in Lazy avoid that. This call to GetOrAdd only initializes the key-value pair,
+             * Wrapping individual value caches in Lazy avoids that. This call to GetOrAdd only initializes the key-value pair,
              * where value is a Lazy that has not been instantiated yet.
              *
              * This will not invoke the factory method yet.

--- a/src/LibSharp/Caching/LazyAsyncExecutionAndPublication.cs
+++ b/src/LibSharp/Caching/LazyAsyncExecutionAndPublication.cs
@@ -61,6 +61,11 @@ namespace LibSharp.Caching
         /// <returns>The value.</returns>
         public async Task<T> GetValueAsync(CancellationToken cancellationToken = default)
         {
+            if (m_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+
             if (!m_hasValue)
             {
                 await m_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/LibSharp/Collections/IEnumerableExtensions.cs
+++ b/src/LibSharp/Collections/IEnumerableExtensions.cs
@@ -118,8 +118,8 @@ namespace LibSharp.Collections
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
         /// <param name="source">The sequence of elements to shuffle.</param>
-        /// <returns>A randomly shuffled sequence.</returns>
-        public static IEnumerable<TSource> Shuffle<TSource>(this IEnumerable<TSource> source)
+        /// <returns>A randomly shuffled array.</returns>
+        public static TSource[] Shuffle<TSource>(this IEnumerable<TSource> source)
         {
             Argument.NotNull(source, nameof(source));
 

--- a/src/LibSharp/Collections/IEnumerableExtensions.cs
+++ b/src/LibSharp/Collections/IEnumerableExtensions.cs
@@ -115,6 +115,7 @@ namespace LibSharp.Collections
 
         /// <summary>
         /// Randomly shuffles the sequence using Fisher-Yates algorithm.
+        /// Does not modify the original collection and returns a new array
         /// </summary>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
         /// <param name="source">The sequence of elements to shuffle.</param>

--- a/src/LibSharp/Common/XmlSerializationExtensions.cs
+++ b/src/LibSharp/Common/XmlSerializationExtensions.cs
@@ -34,7 +34,7 @@ namespace LibSharp.Common
         /// <typeparam name="T">Object type.</typeparam>
         /// <param name="objectToSerialize">Object to serialize.</param>
         /// <returns>XML string.</returns>
-        public static string SerializeToXml<T>(T objectToSerialize)
+        public static string SerializeToXml<T>(this T objectToSerialize)
         {
             Argument.NotNull(objectToSerialize, nameof(objectToSerialize));
 

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -24,9 +24,9 @@ Contains:
 - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
-1.1.1: Changed return type of IEnumerable.Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
-1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
-1.0.0: Initial release. Supports .NET 8.0 only.
+- 1.1.1: Changed return type of IEnumerable.Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
+- 1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
+- 1.0.0: Initial release. Supports .NET 8.0 only.
     </PackageReleaseNotes>
     <PackageTags>LibSharp;Async;Lazy;Cache;Caching;Collections;Extensions</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <PackageId>LibSharp</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Danylo Fitel</Authors>
     <Copyright>Copyright (c) Danylo Fitel 2024</Copyright>
     <Description>
@@ -24,6 +24,7 @@ Contains:
 - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
+1.1.1: Changed return type of IEnumerable.Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
 1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
 1.0.0: Initial release. Supports .NET 8.0 only.
     </PackageReleaseNotes>

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -24,7 +24,9 @@ Contains:
 - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
-- 1.1.1: Changed return type of IEnumerable.Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
+- 1.1.1: Changed return type of Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
+         Fixed the signature of SerializeToXml extension method so it can be called as an extension method.
+         Updated all IDisposable types to throw ObjectDisposedException if a property is accessed on a disposed instance.
 - 1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
 - 1.0.0: Initial release. Supports .NET 8.0 only.
     </PackageReleaseNotes>

--- a/test/LibSharp.UnitTests/Caching/InitializerAsyncExecutionAndPublicationUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/InitializerAsyncExecutionAndPublicationUnitTests.cs
@@ -12,6 +12,31 @@ namespace LibSharp.Caching.UnitTests
     public class InitializerAsyncExecutionAndPublicationUnitTests
     {
         [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void HasValue_ThrowsWhenDisposed()
+        {
+            // Arrange
+            InitializerAsyncExecutionAndPublication<int> initializer = new InitializerAsyncExecutionAndPublication<int>();
+            initializer.Dispose();
+
+            // Act
+            _ = initializer.HasValue;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task GetValueAsync_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            InitializerAsyncExecutionAndPublication<int> initializer = new InitializerAsyncExecutionAndPublication<int>();
+            initializer.Dispose();
+
+            // Act
+            _ = await initializer.GetValueAsync(factory, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [TestMethod]
         public async Task FromValueFactory()
         {
             // Arrange

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) LibSharp. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LibSharp.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace LibSharp.UnitTests.Caching
+{
+    [TestClass]
+    public class KeyValueCacheAsyncUnitTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task GetValueAsync_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<string, CancellationToken, Task<int>> factory = Substitute.For<Func<string, CancellationToken, Task<int>>>();
+            KeyValueCacheAsync<string, int> cache = new KeyValueCacheAsync<string, int>(factory, TimeSpan.FromMinutes(1));
+            cache.Dispose();
+
+            // Act
+            _ = await cache.GetValueAsync("key", CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task KeyValueCache_ValueNotExpired()
+        {
+            // Arrange
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(MockFactory, TimeSpan.FromHours(1));
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+        }
+
+        [TestMethod]
+        public async Task KeyValueCache_ValueExpired()
+        {
+            // Arrange
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(MockFactory, TimeSpan.Zero);
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+        }
+
+        private static Task<int> MockFactory(int key, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(-key);
+        }
+    }
+}

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) LibSharp. All rights reserved.
+
+using System;
+using LibSharp.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibSharp.UnitTests.Caching
+{
+    [TestClass]
+    public class KeyValueCacheUnitTests
+    {
+        [TestMethod]
+        public void KeyValueCache_ValueNotExpired()
+        {
+            // Arrange
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(MockFactory, TimeSpan.FromHours(1));
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+        }
+
+        [TestMethod]
+        public void KeyValueCache_ValueExpired()
+        {
+            // Arrange
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(MockFactory, TimeSpan.Zero);
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+        }
+
+        private static int MockFactory(int key)
+        {
+            return -key;
+        }
+    }
+}

--- a/test/LibSharp.UnitTests/Caching/LazyAsyncExecutionAndPublicationUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/LazyAsyncExecutionAndPublicationUnitTests.cs
@@ -12,6 +12,32 @@ namespace LibSharp.Caching.UnitTests
     public class LazyAsyncExecutionAndPublicationUnitTests
     {
         [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void HasValue_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            LazyAsyncExecutionAndPublication<int> lazy = new LazyAsyncExecutionAndPublication<int>(factory);
+            lazy.Dispose();
+
+            // Act
+            _ = lazy.HasValue;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task GetValueAsync_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            LazyAsyncExecutionAndPublication<int> lazy = new LazyAsyncExecutionAndPublication<int>(factory);
+            lazy.Dispose();
+
+            // Act
+            _ = await lazy.GetValueAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [TestMethod]
         public async Task FromValue()
         {
             // Arrange

--- a/test/LibSharp.UnitTests/Caching/ValueCacheAsyncUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/ValueCacheAsyncUnitTests.cs
@@ -12,6 +12,45 @@ namespace LibSharp.Caching.UnitTests
     public class ValueCacheAsyncUnitTests
     {
         [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void HasValue_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            ValueCacheAsync<int> cache = new ValueCacheAsync<int>(factory, TimeSpan.FromMinutes(1));
+            cache.Dispose();
+
+            // Act
+            _ = cache.HasValue;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void Expiration_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            ValueCacheAsync<int> cache = new ValueCacheAsync<int>(factory, TimeSpan.FromMinutes(1));
+            cache.Dispose();
+
+            // Act
+            _ = cache.Expiration;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task GetValueAsync_ThrowsWhenDisposed()
+        {
+            // Arrange
+            Func<CancellationToken, Task<int>> factory = Substitute.For<Func<CancellationToken, Task<int>>>();
+            ValueCacheAsync<int> cache = new ValueCacheAsync<int>(factory, TimeSpan.FromMinutes(1));
+            cache.Dispose();
+
+            // Act
+            _ = await cache.GetValueAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [TestMethod]
         public async Task FromValueFactory_WhenCacheExpires_RefreshesCache()
         {
             // Arrange

--- a/test/LibSharp.UnitTests/Caching/ValueCacheAsyncUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/ValueCacheAsyncUnitTests.cs
@@ -27,10 +27,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
                     Assert.AreEqual(1, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(2, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -38,6 +40,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(4, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
                 }
 
                 _ = factory.Received(5)(cancellationToken);
@@ -60,10 +63,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
                     Assert.AreEqual(1, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(2, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -71,6 +76,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(4, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
                 }
 
                 _ = factory.Received(5)(cancellationToken);
@@ -97,10 +103,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
                     Assert.AreEqual(1, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(2, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -108,6 +116,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(4, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
                 }
 
                 _ = createFactory.Received(1)(cancellationToken);
@@ -135,10 +144,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
                     Assert.AreEqual(1, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(2, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -146,6 +157,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(4, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
                 }
 
                 _ = createFactory.Received(1)(cancellationToken);
@@ -169,10 +181,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -180,6 +194,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
                 }
 
                 _ = factory.Received(1)(cancellationToken);
@@ -202,10 +217,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -213,6 +230,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
                 }
 
                 _ = factory.Received(1)(cancellationToken);
@@ -237,10 +255,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -248,6 +268,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
                 }
 
                 _ = createFactory.Received(1)(cancellationToken);
@@ -273,10 +294,12 @@ namespace LibSharp.Caching.UnitTests
                 {
                     // Assert
                     Assert.IsFalse(cache.HasValue);
+                    Assert.IsNull(cache.Expiration);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
@@ -284,6 +307,7 @@ namespace LibSharp.Caching.UnitTests
                     Assert.AreEqual(0, await cache.GetValueAsync(cancellationToken).ConfigureAwait(false));
 
                     Assert.IsTrue(cache.HasValue);
+                    Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
                 }
 
                 _ = createFactory.Received(1)(cancellationToken);

--- a/test/LibSharp.UnitTests/Caching/ValueCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/ValueCacheUnitTests.cs
@@ -22,12 +22,38 @@ namespace LibSharp.Caching.UnitTests
         }
 
         [TestMethod]
+        public void FromValueFactoryWithExpirationFunction_WithoutCallsToGetValue_DoesNotExecuteFactory()
+        {
+            // Arrange
+            Func<int> factory = Substitute.For<Func<int>>();
+            ValueCache<int> cache = new ValueCache<int>(factory, _ => DateTime.UtcNow.AddMinutes(1));
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+            _ = factory.DidNotReceive()();
+        }
+
+        [TestMethod]
         public void FromUpdateFactory_WithoutCallsToGetValue_DoesNotExecuteFactory()
         {
             // Arrange
             Func<int> createFactory = Substitute.For<Func<int>>();
             Func<int, int> updateFactory = Substitute.For<Func<int, int>>();
             ValueCache<int> cache = new ValueCache<int>(createFactory, updateFactory, TimeSpan.FromMinutes(1));
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+            _ = createFactory.DidNotReceive()();
+            _ = updateFactory.DidNotReceive()(Arg.Any<int>());
+        }
+
+        [TestMethod]
+        public void FromUpdateFactoryWithExpirationFunction_WithoutCallsToGetValue_DoesNotExecuteFactory()
+        {
+            // Arrange
+            Func<int> createFactory = Substitute.For<Func<int>>();
+            Func<int, int> updateFactory = Substitute.For<Func<int, int>>();
+            ValueCache<int> cache = new ValueCache<int>(createFactory, updateFactory, _ => DateTime.UtcNow.AddMinutes(1));
 
             // Assert
             Assert.IsFalse(cache.HasValue);
@@ -44,6 +70,30 @@ namespace LibSharp.Caching.UnitTests
             _ = factory().Returns(5);
 
             ValueCache<int> cache = new ValueCache<int>(factory, TimeSpan.FromMinutes(1));
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+
+            Assert.AreEqual(5, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+
+            Assert.AreEqual(5, cache.GetValue());
+            Assert.AreEqual(5, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+            _ = factory.Received(1)();
+        }
+
+        [TestMethod]
+        public void FromValueFactoryWithExpirationFunction_InitializesAndReturnsCachedValue()
+        {
+            // Arrange
+            Func<int> factory = Substitute.For<Func<int>>();
+
+            _ = factory().Returns(5);
+
+            ValueCache<int> cache = new ValueCache<int>(factory, _ => DateTime.UtcNow.AddMinutes(1));
 
             // Assert
             Assert.IsFalse(cache.HasValue);
@@ -87,6 +137,33 @@ namespace LibSharp.Caching.UnitTests
         }
 
         [TestMethod]
+        public void FromUpdateFactoryWithExpirationFunction_InitializesAndReturnsCachedValue()
+        {
+            // Arrange
+            Func<int> createFactory = Substitute.For<Func<int>>();
+
+            _ = createFactory().Returns(5);
+
+            Func<int, int> updateFactory = Substitute.For<Func<int, int>>();
+
+            ValueCache<int> cache = new ValueCache<int>(createFactory, updateFactory, _ => DateTime.UtcNow.AddMinutes(1));
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+
+            Assert.AreEqual(5, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+
+            Assert.AreEqual(5, cache.GetValue());
+            Assert.AreEqual(5, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+            _ = createFactory.Received(1)();
+            _ = updateFactory.DidNotReceive()(Arg.Any<int>());
+        }
+
+        [TestMethod]
         public void FromValueFactory_WhenCacheExpires_RefreshesCache()
         {
             // Arrange
@@ -95,6 +172,32 @@ namespace LibSharp.Caching.UnitTests
             _ = factory().Returns(0, 1, 2, 3, 4);
 
             ValueCache<int> cache = new ValueCache<int>(factory, TimeSpan.Zero);
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+
+            Assert.AreEqual(0, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+
+            Assert.AreEqual(1, cache.GetValue());
+            Assert.AreEqual(2, cache.GetValue());
+            Assert.AreEqual(3, cache.GetValue());
+            Assert.AreEqual(4, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+            _ = factory.Received(5)();
+        }
+
+        [TestMethod]
+        public void FromValueFactoryWithExpirationFunction_WhenCacheExpires_RefreshesCache()
+        {
+            // Arrange
+            Func<int> factory = Substitute.For<Func<int>>();
+
+            _ = factory().Returns(0, 1, 2, 3, 4);
+
+            ValueCache<int> cache = new ValueCache<int>(factory, _ => DateTime.UtcNow.AddMinutes(-1));
 
             // Assert
             Assert.IsFalse(cache.HasValue);
@@ -125,6 +228,37 @@ namespace LibSharp.Caching.UnitTests
             _ = updateFactory(Arg.Any<int>()).Returns<int>(x => ((int)x[0]) + 1);
 
             ValueCache<int> cache = new ValueCache<int>(createFactory, updateFactory, TimeSpan.Zero);
+
+            // Assert
+            Assert.IsFalse(cache.HasValue);
+
+            Assert.AreEqual(0, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+
+            Assert.AreEqual(1, cache.GetValue());
+            Assert.AreEqual(2, cache.GetValue());
+            Assert.AreEqual(3, cache.GetValue());
+            Assert.AreEqual(4, cache.GetValue());
+
+            Assert.IsTrue(cache.HasValue);
+            _ = createFactory.Received(1)();
+            _ = updateFactory.Received(4)(Arg.Any<int>());
+        }
+
+        [TestMethod]
+        public void FromUpdateFactoryWithExpirationFunction_WhenCacheExpires_RefreshesCache()
+        {
+            // Arrange
+            Func<int> createFactory = Substitute.For<Func<int>>();
+
+            _ = createFactory().Returns(0);
+
+            Func<int, int> updateFactory = Substitute.For<Func<int, int>>();
+
+            _ = updateFactory(Arg.Any<int>()).Returns<int>(x => ((int)x[0]) + 1);
+
+            ValueCache<int> cache = new ValueCache<int>(createFactory, updateFactory, _ => DateTime.UtcNow.AddMinutes(-1));
 
             // Assert
             Assert.IsFalse(cache.HasValue);

--- a/test/LibSharp.UnitTests/Caching/ValueCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/ValueCacheUnitTests.cs
@@ -18,6 +18,7 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
             _ = factory.DidNotReceive()();
         }
 
@@ -30,6 +31,7 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
             _ = factory.DidNotReceive()();
         }
 
@@ -43,6 +45,7 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
             _ = createFactory.DidNotReceive()();
             _ = updateFactory.DidNotReceive()(Arg.Any<int>());
         }
@@ -57,6 +60,7 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
             _ = createFactory.DidNotReceive()();
             _ = updateFactory.DidNotReceive()(Arg.Any<int>());
         }
@@ -73,15 +77,18 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(5, cache.GetValue());
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = factory.Received(1)();
         }
 
@@ -97,15 +104,18 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(5, cache.GetValue());
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = factory.Received(1)();
         }
 
@@ -123,15 +133,18 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(5, cache.GetValue());
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = createFactory.Received(1)();
             _ = updateFactory.DidNotReceive()(Arg.Any<int>());
         }
@@ -150,15 +163,18 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(5, cache.GetValue());
             Assert.AreEqual(5, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = createFactory.Received(1)();
             _ = updateFactory.DidNotReceive()(Arg.Any<int>());
         }
@@ -175,10 +191,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
             Assert.AreEqual(1, cache.GetValue());
             Assert.AreEqual(2, cache.GetValue());
@@ -186,6 +204,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(4, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
             _ = factory.Received(5)();
         }
 
@@ -201,10 +220,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
             Assert.AreEqual(1, cache.GetValue());
             Assert.AreEqual(2, cache.GetValue());
@@ -212,6 +233,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(4, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
             _ = factory.Received(5)();
         }
 
@@ -231,10 +253,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
             Assert.AreEqual(1, cache.GetValue());
             Assert.AreEqual(2, cache.GetValue());
@@ -242,6 +266,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(4, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
             _ = createFactory.Received(1)();
             _ = updateFactory.Received(4)(Arg.Any<int>());
         }
@@ -262,10 +287,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
 
             Assert.AreEqual(1, cache.GetValue());
             Assert.AreEqual(2, cache.GetValue());
@@ -273,6 +300,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(4, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration <= DateTime.UtcNow);
             _ = createFactory.Received(1)();
             _ = updateFactory.Received(4)(Arg.Any<int>());
         }
@@ -289,10 +317,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(0, cache.GetValue());
             Assert.AreEqual(0, cache.GetValue());
@@ -300,6 +330,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = factory.Received(1)();
         }
 
@@ -317,10 +348,12 @@ namespace LibSharp.Caching.UnitTests
 
             // Assert
             Assert.IsFalse(cache.HasValue);
+            Assert.IsNull(cache.Expiration);
 
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
 
             Assert.AreEqual(0, cache.GetValue());
             Assert.AreEqual(0, cache.GetValue());
@@ -328,6 +361,7 @@ namespace LibSharp.Caching.UnitTests
             Assert.AreEqual(0, cache.GetValue());
 
             Assert.IsTrue(cache.HasValue);
+            Assert.IsTrue(cache.Expiration >= DateTime.UtcNow);
             _ = createFactory.Received(1)();
             _ = updateFactory.DidNotReceive()(Arg.Any<int>());
         }

--- a/test/LibSharp.UnitTests/Collections/IEnumerableExtensionsTests.cs
+++ b/test/LibSharp.UnitTests/Collections/IEnumerableExtensionsTests.cs
@@ -30,10 +30,7 @@ namespace LibSharp.Collections.UnitTests
             string[] items = new[] { "value" };
 
             // Act
-            List<List<string>> chunks = items
-                .Chunk(100, _ => 1)
-                .Select(batch => batch.ToList())
-                .ToList();
+            List<List<string>> chunks = items.Chunk(100, _ => 1).ToList();
 
             // Act
             Assert.AreEqual(1, chunks.Count);
@@ -48,10 +45,7 @@ namespace LibSharp.Collections.UnitTests
             List<int> items = Enumerable.Range(0, 10).ToList();
 
             // Act
-            List<List<int>> chunks = items
-                .Chunk(20, _ => 1)
-                .Select(batch => batch.ToList())
-                .ToList();
+            List<List<int>> chunks = items.Chunk(20, _ => 1).ToList();
 
             // Act
             Assert.AreEqual(1, chunks.Count);
@@ -70,10 +64,7 @@ namespace LibSharp.Collections.UnitTests
             List<int> items = Enumerable.Range(0, 10).ToList();
 
             // Act
-            List<List<int>> chunks = items
-                .Chunk(10, _ => 1)
-                .Select(batch => batch.ToList())
-                .ToList();
+            List<List<int>> chunks = items.Chunk(10, _ => 1).ToList();
 
             // Act
             Assert.AreEqual(1, chunks.Count);
@@ -92,10 +83,7 @@ namespace LibSharp.Collections.UnitTests
             List<int> items = Enumerable.Range(0, 100).Select(i => i % 10).ToList();
 
             // Act
-            List<List<int>> chunks = items
-                .Chunk(10, _ => 1)
-                .Select(batch => batch.ToList())
-                .ToList();
+            List<List<int>> chunks = items.Chunk(10, _ => 1).ToList();
 
             // Act
             Assert.AreEqual(10, chunks.Count);
@@ -118,10 +106,7 @@ namespace LibSharp.Collections.UnitTests
             List<int> items = Enumerable.Range(0, 101).Select(i => i % 10).ToList();
 
             // Act
-            List<List<int>> chunks = items
-                .Chunk(10, _ => 1)
-                .Select(batch => batch.ToList())
-                .ToList();
+            List<List<int>> chunks = items.Chunk(10, _ => 1).ToList();
 
             // Act
             Assert.AreEqual(11, chunks.Count);
@@ -257,10 +242,10 @@ namespace LibSharp.Collections.UnitTests
         public void Shuffle_EmptyEnumerable()
         {
             // Act
-            List<int> output = Enumerable.Empty<int>().Shuffle().ToList();
+            int[] output = Enumerable.Empty<int>().Shuffle();
 
             // Assert
-            Assert.AreEqual(0, output.Count);
+            Assert.AreEqual(0, output.Length);
         }
 
         [TestMethod]
@@ -270,7 +255,7 @@ namespace LibSharp.Collections.UnitTests
             List<int> input = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
             // Act
-            List<int> output = input.Shuffle().ToList();
+            int[] output = input.Shuffle();
 
             // Assert
             CollectionAssert.AreEquivalent(input, output);

--- a/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
@@ -745,7 +745,7 @@ namespace LibSharp.Collections.UnitTests
         public void GetEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            List<int> collection = Enumerable.Range(0, 100).Shuffle().ToList();
+            int[] collection = Enumerable.Range(0, 100).Shuffle();
             MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(collection);
 
             // Act
@@ -763,7 +763,7 @@ namespace LibSharp.Collections.UnitTests
         public void GetWeakEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            List<int> collection = Enumerable.Range(0, 100).Shuffle().ToList();
+            int[] collection = Enumerable.Range(0, 100).Shuffle();
             IEnumerable queue = new MaxPriorityQueue<int>(collection);
 
             // Act

--- a/test/LibSharp.UnitTests/Collections/ReverseComparerUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/ReverseComparerUnitTests.cs
@@ -21,8 +21,8 @@ namespace LibSharp.Collections.UnitTests
         public void Compare_ReturnsReversedResult()
         {
             // Arrange
-            IComparer<int> normal = Comparer<int>.Default;
-            IComparer<int> reverse = new ReverseComparer<int>(Comparer<int>.Default);
+            Comparer<int> normal = Comparer<int>.Default;
+            ReverseComparer<int> reverse = new ReverseComparer<int>(Comparer<int>.Default);
 
             // Assert
             Assert.AreEqual(normal.Compare(1, 1), reverse.Compare(1, 1));

--- a/test/LibSharp.UnitTests/Common/XmlSerializationExtensionsUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/XmlSerializationExtensionsUnitTests.cs
@@ -13,7 +13,7 @@ namespace LibSharp.UnitTests.Common
         public void XmlSerializationTest()
         {
             // Arrange
-            List<string> original = ["a", "bb", "ccc"];
+            List<string> original = new List<string> { "a", "bb", "ccc" };
 
             // Act
             string serialized = original.SerializeToXml();

--- a/test/LibSharp.UnitTests/Common/XmlSerializationExtensionsUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/XmlSerializationExtensionsUnitTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) LibSharp. All rights reserved.
+
+using System.Collections.Generic;
+using LibSharp.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibSharp.UnitTests.Common
+{
+    [TestClass]
+    public class XmlSerializationExtensionsUnitTests
+    {
+        [TestMethod]
+        public void XmlSerializationTest()
+        {
+            // Arrange
+            List<string> original = ["a", "bb", "ccc"];
+
+            // Act
+            string serialized = original.SerializeToXml();
+            List<string> deserialized = serialized.DeserializeFromXml<List<string>>();
+
+            // Assert
+            CollectionAssert.AreEquivalent(original, deserialized);
+        }
+    }
+}

--- a/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
+++ b/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />

--- a/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
+++ b/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
@@ -13,10 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Change return type of Shuffle extension method to return an array.
Throw ObjectDisposedException if a property is accessed on a disposed instance.