### PR TITLE
Version 1.1.2

### DIFF
--- a/src/LibSharp/Caching/InitializerAsyncPublicationOnly.cs
+++ b/src/LibSharp/Caching/InitializerAsyncPublicationOnly.cs
@@ -15,7 +15,7 @@ namespace LibSharp.Caching
     public class InitializerAsyncPublicationOnly<T> : IInitializerAsync<T>
     {
         /// <inheritdoc/>
-        public bool HasValue => m_value != null;
+        public bool HasValue => m_value is not null;
 
         /// <inheritdoc/>
         public async Task<T> GetValueAsync(Func<CancellationToken, Task<T>> factory, CancellationToken cancellationToken = default)

--- a/src/LibSharp/Caching/KeyValueCache.cs
+++ b/src/LibSharp/Caching/KeyValueCache.cs
@@ -24,8 +24,56 @@ namespace LibSharp.Caching
             Argument.NotNull(factory, nameof(factory));
             Argument.GreaterThanOrEqualTo(timeToLive, TimeSpan.Zero, nameof(timeToLive));
 
-            m_factory = factory;
+            m_createFactory = factory;
             m_timeToLive = timeToLive;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValueCache{TKey, TValue}"/> class from a value factory.
+        /// </summary>
+        /// <param name="factory">The value factory.</param>
+        /// <param name="expirationFunction">Function to calculate expiration of a value.</param>
+        public KeyValueCache(Func<TKey, TValue> factory, Func<TKey, TValue, DateTime> expirationFunction)
+        {
+            Argument.NotNull(factory, nameof(factory));
+            Argument.NotNull(expirationFunction, nameof(expirationFunction));
+
+            m_createFactory = factory;
+            m_expirationFunction = expirationFunction;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValueCache{TKey, TValue}"/> class from a creation factory, used to initialize the cache, and update factory, used to refresh it.
+        /// </summary>
+        /// <param name="createFactory">The creation factory.</param>
+        /// <param name="updateFactory">The update factory.</param>
+        /// <param name="timeToLive">Cache time-to-live.</param>
+        public KeyValueCache(Func<TKey, TValue> createFactory, Func<TKey, TValue, TValue> updateFactory, TimeSpan timeToLive)
+        {
+            Argument.NotNull(createFactory, nameof(createFactory));
+            Argument.NotNull(updateFactory, nameof(updateFactory));
+            Argument.GreaterThanOrEqualTo(timeToLive, TimeSpan.Zero, nameof(timeToLive));
+
+            m_createFactory = createFactory;
+            m_updateFactory = updateFactory;
+            m_timeToLive = timeToLive;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyValueCache{TKey, TValue}"/> class from a creation factory, used to initialize the cache, and update factory, used to refresh it.
+        /// </summary>
+        /// <param name="createFactory">The creation factory.</param>
+        /// <param name="updateFactory">The update factory.</param>
+        /// <param name="expirationFunction">Function to calculate expiration of a value.</param>
+        public KeyValueCache(Func<TKey, TValue> createFactory, Func<TKey, TValue, TValue> updateFactory, Func<TKey, TValue, DateTime> expirationFunction)
+        {
+            Argument.NotNull(createFactory, nameof(createFactory));
+            Argument.NotNull(updateFactory, nameof(updateFactory));
+            Argument.NotNull(expirationFunction, nameof(expirationFunction));
+
+            m_createFactory = createFactory;
+            m_updateFactory = updateFactory;
+            m_expirationFunction = expirationFunction;
         }
 
         /// <inheritdoc/>
@@ -33,16 +81,30 @@ namespace LibSharp.Caching
         {
             Argument.NotNull(key, nameof(key));
 
-            ValueCache<TValue> valueCache = m_cache.GetOrAdd(
-                key,
-                cacheKey => new ValueCache<TValue>(() => m_factory(cacheKey), m_timeToLive));
+            ValueCache<TValue> valueCache = m_cache.GetOrAdd(key, CreateValueCache);
 
             return valueCache.GetValue();
         }
 
+        private ValueCache<TValue> CreateValueCache(TKey key)
+        {
+            if (m_updateFactory is null)
+            {
+                return m_timeToLive.HasValue
+                    ? new ValueCache<TValue>(() => m_createFactory(key), m_timeToLive.Value)
+                    : new ValueCache<TValue>(() => m_createFactory(key), value => m_expirationFunction(key, value));
+            }
+
+            return m_timeToLive.HasValue
+                ? new ValueCache<TValue>(() => m_createFactory(key), value => m_updateFactory(key, value), m_timeToLive.Value)
+                : new ValueCache<TValue>(() => m_createFactory(key), value => m_updateFactory(key, value), value => m_expirationFunction(key, value));
+        }
+
         private readonly ConcurrentDictionary<TKey, ValueCache<TValue>> m_cache = new ConcurrentDictionary<TKey, ValueCache<TValue>>();
 
-        private readonly Func<TKey, TValue> m_factory;
-        private readonly TimeSpan m_timeToLive;
+        private readonly Func<TKey, TValue> m_createFactory;
+        private readonly Func<TKey, TValue, TValue> m_updateFactory;
+        private readonly TimeSpan? m_timeToLive;
+        private readonly Func<TKey, TValue, DateTime> m_expirationFunction;
     }
 }

--- a/src/LibSharp/Caching/LazyAsyncPublicationOnly.cs
+++ b/src/LibSharp/Caching/LazyAsyncPublicationOnly.cs
@@ -39,7 +39,7 @@ namespace LibSharp.Caching
         /// <summary>
         /// Gets a value indicating whether the value has been initialized.
         /// </summary>
-        public bool HasValue => m_value != null;
+        public bool HasValue => m_value is not null;
 
         /// <summary>
         /// Gets the value.

--- a/src/LibSharp/Caching/ValueCache.cs
+++ b/src/LibSharp/Caching/ValueCache.cs
@@ -75,7 +75,7 @@ namespace LibSharp.Caching
         }
 
         /// <inheritdoc/>
-        public bool HasValue => m_boxed != null;
+        public bool HasValue => m_boxed is not null;
 
         /// <inheritdoc/>
         public DateTime? Expiration => m_boxed?.Expiration;
@@ -83,11 +83,11 @@ namespace LibSharp.Caching
         /// <inheritdoc/>
         public T GetValue()
         {
-            if (m_boxed == null || DateTime.UtcNow >= m_boxed.Expiration)
+            if (m_boxed is null || DateTime.UtcNow >= m_boxed.Expiration)
             {
                 lock (m_lock)
                 {
-                    if (m_boxed == null || DateTime.UtcNow >= m_boxed.Expiration)
+                    if (m_boxed is null || DateTime.UtcNow >= m_boxed.Expiration)
                     {
                         Refresh();
                     }
@@ -105,7 +105,7 @@ namespace LibSharp.Caching
         private void Refresh()
         {
             T newValue;
-            if (m_updateFactory == null || m_boxed == null)
+            if (m_updateFactory is null || m_boxed is null)
             {
                 newValue = m_createFactory();
             }

--- a/src/LibSharp/Caching/ValueCache.cs
+++ b/src/LibSharp/Caching/ValueCache.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
 using System;
-using System.Diagnostics;
 using LibSharp.Common;
 
 namespace LibSharp.Caching
@@ -24,7 +23,7 @@ namespace LibSharp.Caching
             Argument.GreaterThanOrEqualTo(timeToLive, TimeSpan.Zero, nameof(timeToLive));
 
             m_createFactory = factory;
-            m_timeToLive = timeToLive;
+            m_expirationFunction = _ => GetExpiration(timeToLive);
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ namespace LibSharp.Caching
 
             m_createFactory = createFactory;
             m_updateFactory = updateFactory;
-            m_timeToLive = timeToLive;
+            m_expirationFunction = _ => GetExpiration(timeToLive);
         }
 
         /// <summary>
@@ -98,9 +97,11 @@ namespace LibSharp.Caching
             return m_boxed.Value;
         }
 
-        /// <summary>
-        /// Initializes or updates the cache.
-        /// </summary>
+        private static DateTime GetExpiration(TimeSpan timeToLive)
+        {
+            return timeToLive == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow.Add(timeToLive);
+        }
+
         private void Refresh()
         {
             T newValue;
@@ -113,23 +114,7 @@ namespace LibSharp.Caching
                 newValue = m_updateFactory(m_boxed.Value);
             }
 
-            DateTime newExpiration;
-            if (m_timeToLive.HasValue)
-            {
-                if (m_timeToLive.Value == TimeSpan.MaxValue)
-                {
-                    newExpiration = DateTime.MaxValue;
-                }
-                else
-                {
-                    newExpiration = DateTime.UtcNow.Add(m_timeToLive.Value);
-                }
-            }
-            else
-            {
-                Debug.Assert(m_expirationFunction != null, "Expiration function cannot be null if time to live is null.");
-                newExpiration = m_expirationFunction(newValue);
-            }
+            DateTime newExpiration = m_expirationFunction(newValue);
 
             m_boxed = new ValueReference<T>(newValue, newExpiration);
         }
@@ -138,7 +123,6 @@ namespace LibSharp.Caching
 
         private readonly Func<T> m_createFactory;
         private readonly Func<T, T> m_updateFactory;
-        private readonly TimeSpan? m_timeToLive;
         private readonly Func<T, DateTime> m_expirationFunction;
 
         private ValueReference<T> m_boxed;

--- a/src/LibSharp/Caching/ValueCacheAsync.cs
+++ b/src/LibSharp/Caching/ValueCacheAsync.cs
@@ -86,7 +86,7 @@ namespace LibSharp.Caching
                     throw new ObjectDisposedException(GetType().FullName);
                 }
 
-                return m_boxed != null;
+                return m_boxed is not null;
             }
         }
 
@@ -112,13 +112,13 @@ namespace LibSharp.Caching
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            if (m_boxed == null || DateTime.UtcNow >= m_boxed.Expiration)
+            if (m_boxed is null || DateTime.UtcNow >= m_boxed.Expiration)
             {
                 await m_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 try
                 {
-                    if (m_boxed == null || DateTime.UtcNow >= m_boxed.Expiration)
+                    if (m_boxed is null || DateTime.UtcNow >= m_boxed.Expiration)
                     {
                         await Refresh(cancellationToken).ConfigureAwait(false);
                     }
@@ -166,7 +166,7 @@ namespace LibSharp.Caching
         private async Task Refresh(CancellationToken cancellationToken)
         {
             T newValue;
-            if (m_updateFactory == null || m_boxed == null)
+            if (m_updateFactory is null || m_boxed is null)
             {
                 newValue = await m_createFactory(cancellationToken).ConfigureAwait(false);
             }

--- a/src/LibSharp/Caching/ValueCacheAsync.cs
+++ b/src/LibSharp/Caching/ValueCacheAsync.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using LibSharp.Common;
@@ -26,7 +25,7 @@ namespace LibSharp.Caching
             Argument.GreaterThanOrEqualTo(timeToLive, TimeSpan.Zero, nameof(timeToLive));
 
             m_createFactory = factory;
-            m_timeToLive = timeToLive;
+            m_expirationFunction = _ => GetExpiration(timeToLive);
         }
 
         /// <summary>
@@ -57,7 +56,7 @@ namespace LibSharp.Caching
 
             m_createFactory = createFactory;
             m_updateFactory = updateFactory;
-            m_timeToLive = timeToLive;
+            m_expirationFunction = _ => GetExpiration(timeToLive);
         }
 
         /// <summary>
@@ -159,10 +158,11 @@ namespace LibSharp.Caching
             }
         }
 
-        /// <summary>
-        /// Initializes or updates the cache.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token.</param>
+        private static DateTime GetExpiration(TimeSpan timeToLive)
+        {
+            return timeToLive == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow.Add(timeToLive);
+        }
+
         private async Task Refresh(CancellationToken cancellationToken)
         {
             T newValue;
@@ -175,23 +175,7 @@ namespace LibSharp.Caching
                 newValue = await m_updateFactory(m_boxed.Value, cancellationToken).ConfigureAwait(false);
             }
 
-            DateTime newExpiration;
-            if (m_timeToLive.HasValue)
-            {
-                if (m_timeToLive.Value == TimeSpan.MaxValue)
-                {
-                    newExpiration = DateTime.MaxValue;
-                }
-                else
-                {
-                    newExpiration = DateTime.UtcNow.Add(m_timeToLive.Value);
-                }
-            }
-            else
-            {
-                Debug.Assert(m_expirationFunction != null, "Expiration function cannot be null if time to live is null.");
-                newExpiration = m_expirationFunction(newValue);
-            }
+            DateTime newExpiration = m_expirationFunction(newValue);
 
             m_boxed = new ValueReference<T>(newValue, newExpiration);
         }
@@ -200,7 +184,6 @@ namespace LibSharp.Caching
 
         private readonly Func<CancellationToken, Task<T>> m_createFactory;
         private readonly Func<T, CancellationToken, Task<T>> m_updateFactory;
-        private readonly TimeSpan? m_timeToLive;
         private readonly Func<T, DateTime> m_expirationFunction;
 
         private ValueReference<T> m_boxed;

--- a/src/LibSharp/Collections/MinPriorityQueue.cs
+++ b/src/LibSharp/Collections/MinPriorityQueue.cs
@@ -288,7 +288,7 @@ namespace LibSharp.Collections
             for (int i = 1; i <= Count; ++i)
             {
                 T currentItem = m_heap[i];
-                if ((item == null && currentItem == null) || (item != null && item.Equals(currentItem)))
+                if ((item is null && currentItem is null) || (item is not null && item.Equals(currentItem)))
                 {
                     return i;
                 }

--- a/src/LibSharp/Common/Argument.cs
+++ b/src/LibSharp/Common/Argument.cs
@@ -18,12 +18,12 @@ namespace LibSharp.Common
         /// <typeparam name="T">Argument type.</typeparam>
         public static void EqualTo<T>(T value, T equalValue, string name)
         {
-            if (value == null && equalValue == null)
+            if (value is null && equalValue is null)
             {
                 return;
             }
 
-            if (value == null && equalValue != null)
+            if (value is null && equalValue is not null)
             {
                 throw new ArgumentNullException(name, $"Argument is null and is not equal to {equalValue}");
             }
@@ -115,12 +115,12 @@ namespace LibSharp.Common
         /// <typeparam name="T">Argument type.</typeparam>
         public static void NotEqualTo<T>(T value, T notEqualValue, string name)
         {
-            if (value == null && notEqualValue == null)
+            if (value is null && notEqualValue is null)
             {
                 throw new ArgumentNullException(name);
             }
 
-            if (value == null || notEqualValue == null)
+            if (value is null || notEqualValue is null)
             {
                 return;
             }
@@ -138,7 +138,7 @@ namespace LibSharp.Common
         /// <param name="name">Argument name.</param>
         public static void NotNull(object value, string name)
         {
-            if (value == null)
+            if (value is null)
             {
                 throw new ArgumentNullException(name);
             }

--- a/src/LibSharp/Common/Box.cs
+++ b/src/LibSharp/Common/Box.cs
@@ -46,7 +46,7 @@ namespace LibSharp.Common
         /// <inheritdoc/>
         public bool Equals(T other)
         {
-            return (!HasValue && other == null)
+            return (!HasValue && other is null)
                 || (HasValue && Value.Equals(other));
         }
 

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -25,7 +25,7 @@ Contains:
     </Description>
     <PackageReleaseNotes>
 - 1.1.2: Added more constructors to KeyValueCache and KeyValueCacheAsync that allow to provide separate factories for creates and updates, and to specify custom expiration function.
-- 1.1.1: Changed return type of Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
+- 1.1.1: Changed return type of Shuffle extension method to return an array instead of an IEnumerable to not force the callers to create extra copies.
          Fixed the signature of SerializeToXml extension method so it can be called as an extension method.
          Updated all IDisposable types to throw ObjectDisposedException if a property is accessed on a disposed instance.
 - 1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <PackageId>LibSharp</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Authors>Danylo Fitel</Authors>
     <Copyright>Copyright (c) Danylo Fitel 2024</Copyright>
     <Description>
@@ -24,13 +24,14 @@ Contains:
 - Argument validation methods.
     </Description>
     <PackageReleaseNotes>
+- 1.1.2: Added more constructors to KeyValueCache and KeyValueCacheAsync that allow to provide separate factories for creates and updates, and to specify custom expiration function.
 - 1.1.1: Changed return type of Shuffle extension method to return an array instead of IEnumerable to not force the callers to create extra copies.
          Fixed the signature of SerializeToXml extension method so it can be called as an extension method.
          Updated all IDisposable types to throw ObjectDisposedException if a property is accessed on a disposed instance.
 - 1.1.0: Added support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0. Updated documentation and added examples.
 - 1.0.0: Initial release. Supports .NET 8.0 only.
     </PackageReleaseNotes>
-    <PackageTags>LibSharp;Async;Lazy;Cache;Caching;Collections;Extensions</PackageTags>
+    <PackageTags>LibSharp;Async Lazy;Cache;Async Cache;Thread Safe Cache;Priority Queue;Collections;Extensions</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://www.nuget.org/packages/LibSharp</PackageProjectUrl>

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
@@ -26,7 +26,7 @@ namespace LibSharp.UnitTests.Caching
         }
 
         [TestMethod]
-        public async Task KeyValueCache_ValueNotExpired()
+        public async Task KeyValueCacheAsync_TimeToLive_ValueNotExpired()
         {
             // Arrange
             Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
@@ -71,7 +71,7 @@ namespace LibSharp.UnitTests.Caching
         }
 
         [TestMethod]
-        public async Task KeyValueCache_ValueExpired()
+        public async Task KeyValueCacheAsync_TimeToLive_ValueExpired()
         {
             // Arrange
             Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
@@ -113,6 +113,316 @@ namespace LibSharp.UnitTests.Caching
             Assert.AreEqual(-2, value);
             _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
             _ = factory.Received(2)(2, Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_ExpirationFunction_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = factory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(factory, (_, _) => DateTime.UtcNow.AddHours(1));
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_ExpirationFunction_ValueExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = factory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(factory, (_, _) => DateTime.UtcNow);
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(2)(2, Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_UpdateFactory_TimeToLive_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> createFactory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = createFactory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            Func<int, int, CancellationToken, Task<int>> updateFactory = Substitute.For<Func<int, int, CancellationToken, Task<int>>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(((int)x[1]) * 10));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(createFactory, updateFactory, TimeSpan.FromHours(1));
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_UpdateFactory_TimeToLive_ValueExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> createFactory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = createFactory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            Func<int, int, CancellationToken, Task<int>> updateFactory = Substitute.For<Func<int, int, CancellationToken, Task<int>>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(((int)x[1]) * 10));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(createFactory, updateFactory, TimeSpan.Zero);
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-10, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-20, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_UpdateFactory_ExpirationFunction_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> createFactory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = createFactory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            Func<int, int, CancellationToken, Task<int>> updateFactory = Substitute.For<Func<int, int, CancellationToken, Task<int>>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(((int)x[1]) * 10));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(createFactory, updateFactory, (_, _) => DateTime.UtcNow.AddHours(1));
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task KeyValueCacheAsync_UpdateFactory_ExpirationFunction_ValueExpired()
+        {
+            // Arrange
+            Func<int, CancellationToken, Task<int>> createFactory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = createFactory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            Func<int, int, CancellationToken, Task<int>> updateFactory = Substitute.For<Func<int, int, CancellationToken, Task<int>>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(((int)x[1]) * 10));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(createFactory, updateFactory, (_, _) => DateTime.UtcNow);
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            int value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(1).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-10, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(0)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            // Act
+            value = await cache.GetValueAsync(2).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(-20, value);
+            _ = createFactory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = createFactory.Received(1)(2, Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(1, Arg.Any<int>(), Arg.Any<CancellationToken>());
+            _ = updateFactory.Received(1)(2, Arg.Any<int>(), Arg.Any<CancellationToken>());
         }
     }
 }

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheAsyncUnitTests.cs
@@ -17,80 +17,102 @@ namespace LibSharp.UnitTests.Caching
         public async Task GetValueAsync_ThrowsWhenDisposed()
         {
             // Arrange
-            Func<string, CancellationToken, Task<int>> factory = Substitute.For<Func<string, CancellationToken, Task<int>>>();
-            KeyValueCacheAsync<string, int> cache = new KeyValueCacheAsync<string, int>(factory, TimeSpan.FromMinutes(1));
+            Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(factory, TimeSpan.FromMinutes(1));
             cache.Dispose();
 
             // Act
-            _ = await cache.GetValueAsync("key", CancellationToken.None).ConfigureAwait(false);
+            _ = await cache.GetValueAsync(1, CancellationToken.None).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task KeyValueCache_ValueNotExpired()
         {
             // Arrange
-            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(MockFactory, TimeSpan.FromHours(1));
+            Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = factory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(factory, TimeSpan.FromHours(1));
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
 
             // Act
             int value = await cache.GetValueAsync(1).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(1).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(2).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(2).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
         }
 
         [TestMethod]
         public async Task KeyValueCache_ValueExpired()
         {
             // Arrange
-            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(MockFactory, TimeSpan.Zero);
+            Func<int, CancellationToken, Task<int>> factory = Substitute.For<Func<int, CancellationToken, Task<int>>>();
+            _ = factory(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(x => Task.FromResult(-((int)x[0])));
+
+            using KeyValueCacheAsync<int, int> cache = new KeyValueCacheAsync<int, int>(factory, TimeSpan.Zero);
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>(), Arg.Any<CancellationToken>());
 
             // Act
             int value = await cache.GetValueAsync(1).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(1).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(0)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(2).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(1)(2, Arg.Any<CancellationToken>());
 
             // Act
             value = await cache.GetValueAsync(2).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(-2, value);
-        }
-
-        private static Task<int> MockFactory(int key, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(-key);
+            _ = factory.Received(2)(1, Arg.Any<CancellationToken>());
+            _ = factory.Received(2)(2, Arg.Any<CancellationToken>());
         }
     }
 }

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
@@ -3,6 +3,7 @@
 using System;
 using LibSharp.Caching;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
 
 namespace LibSharp.UnitTests.Caching
 {
@@ -13,67 +14,90 @@ namespace LibSharp.UnitTests.Caching
         public void KeyValueCache_ValueNotExpired()
         {
             // Arrange
-            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(MockFactory, TimeSpan.FromHours(1));
+            Func<int, int> factory = Substitute.For<Func<int, int>>();
+            _ = factory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(factory, TimeSpan.FromHours(1));
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>());
 
             // Act
             int value = cache.GetValue(1);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
 
             // Act
             value = cache.GetValue(1);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
 
             // Act
             value = cache.GetValue(2);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(1)(2);
 
             // Act
             value = cache.GetValue(2);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(1)(2);
         }
 
         [TestMethod]
         public void KeyValueCache_ValueExpired()
         {
             // Arrange
-            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(MockFactory, TimeSpan.Zero);
+            Func<int, int> factory = Substitute.For<Func<int, int>>();
+            _ = factory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(factory, TimeSpan.Zero);
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>());
 
             // Act
             int value = cache.GetValue(1);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
 
             // Act
             value = cache.GetValue(1);
 
             // Assert
             Assert.AreEqual(-1, value);
+            _ = factory.Received(2)(1);
+            _ = factory.Received(0)(2);
 
             // Act
             value = cache.GetValue(2);
 
             // Assert
             Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1);
+            _ = factory.Received(1)(2);
 
             // Act
             value = cache.GetValue(2);
 
             // Assert
             Assert.AreEqual(-2, value);
-        }
-
-        private static int MockFactory(int key)
-        {
-            return -key;
+            _ = factory.Received(2)(1);
+            _ = factory.Received(2)(2);
         }
     }
 }

--- a/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/KeyValueCacheUnitTests.cs
@@ -11,7 +11,7 @@ namespace LibSharp.UnitTests.Caching
     public class KeyValueCacheUnitTests
     {
         [TestMethod]
-        public void KeyValueCache_ValueNotExpired()
+        public void KeyValueCache_TimeToLive_ValueNotExpired()
         {
             // Arrange
             Func<int, int> factory = Substitute.For<Func<int, int>>();
@@ -56,7 +56,7 @@ namespace LibSharp.UnitTests.Caching
         }
 
         [TestMethod]
-        public void KeyValueCache_ValueExpired()
+        public void KeyValueCache_TimeToLive_ValueExpired()
         {
             // Arrange
             Func<int, int> factory = Substitute.For<Func<int, int>>();
@@ -98,6 +98,316 @@ namespace LibSharp.UnitTests.Caching
             Assert.AreEqual(-2, value);
             _ = factory.Received(2)(1);
             _ = factory.Received(2)(2);
+        }
+
+        [TestMethod]
+        public void KeyValueCache_ExpirationFunction_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, int> factory = Substitute.For<Func<int, int>>();
+            _ = factory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(factory, (_, _) => DateTime.UtcNow.AddHours(1));
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(1)(2);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(1)(2);
+        }
+
+        [TestMethod]
+        public void KeyValueCache_ExpirationFunction_ValueExpired()
+        {
+            // Arrange
+            Func<int, int> factory = Substitute.For<Func<int, int>>();
+            _ = factory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(factory, (_, _) => DateTime.UtcNow);
+
+            // Assert
+            _ = factory.Received(0)(Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(1)(1);
+            _ = factory.Received(0)(2);
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = factory.Received(2)(1);
+            _ = factory.Received(0)(2);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1);
+            _ = factory.Received(1)(2);
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = factory.Received(2)(1);
+            _ = factory.Received(2)(2);
+        }
+
+        [TestMethod]
+        public void KeyValueCache_UpdateFactory_TimeToLive_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, int> createFactory = Substitute.For<Func<int, int>>();
+            _ = createFactory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            Func<int, int, int> updateFactory = Substitute.For<Func<int, int, int>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>()).Returns(x => ((int)x[1]) * 10);
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(createFactory, TimeSpan.FromHours(1));
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+        }
+
+        [TestMethod]
+        public void KeyValueCache_UpdateFactory_TimeToLive_ValueExpired()
+        {
+            // Arrange
+            Func<int, int> createFactory = Substitute.For<Func<int, int>>();
+            _ = createFactory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            Func<int, int, int> updateFactory = Substitute.For<Func<int, int, int>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>()).Returns(x => ((int)x[1]) * 10);
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(createFactory, updateFactory, TimeSpan.Zero);
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(1, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-10, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-20, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(1)(2, Arg.Any<int>());
+        }
+
+        [TestMethod]
+        public void KeyValueCache_UpdateFactory_ExpirationFunction_ValueNotExpired()
+        {
+            // Arrange
+            Func<int, int> createFactory = Substitute.For<Func<int, int>>();
+            _ = createFactory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            Func<int, int, int> updateFactory = Substitute.For<Func<int, int, int>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>()).Returns(x => ((int)x[1]) * 10);
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(createFactory, updateFactory, (_, _) => DateTime.UtcNow.AddHours(1));
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+        }
+
+        [TestMethod]
+        public void KeyValueCache_UpdateFactory_ExpirationFunction_ValueExpired()
+        {
+            // Arrange
+            Func<int, int> createFactory = Substitute.For<Func<int, int>>();
+            _ = createFactory(Arg.Any<int>()).Returns(x => -((int)x[0]));
+
+            Func<int, int, int> updateFactory = Substitute.For<Func<int, int, int>>();
+            _ = updateFactory(Arg.Any<int>(), Arg.Any<int>()).Returns(x => ((int)x[1]) * 10);
+
+            KeyValueCache<int, int> cache = new KeyValueCache<int, int>(createFactory, updateFactory, (_, _) => DateTime.UtcNow);
+
+            // Assert
+            _ = createFactory.Received(0)(Arg.Any<int>());
+            _ = updateFactory.Received(0)(Arg.Any<int>(), Arg.Any<int>());
+
+            // Act
+            int value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-1, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(0)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(1, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(1);
+
+            // Assert
+            Assert.AreEqual(-10, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(0)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-2, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(0)(2, Arg.Any<int>());
+
+            // Act
+            value = cache.GetValue(2);
+
+            // Assert
+            Assert.AreEqual(-20, value);
+            _ = createFactory.Received(1)(1);
+            _ = createFactory.Received(1)(2);
+            _ = updateFactory.Received(1)(1, Arg.Any<int>());
+            _ = updateFactory.Received(1)(2, Arg.Any<int>());
         }
     }
 }


### PR DESCRIPTION
Added more constructors to KeyValueCache and KeyValueCacheAsync that allow to provide separate factories for creates and updates, and to specify custom expiration function.
100% unit test coverage.