### PR TITLE
Version 2.0.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,6 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:warning
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
@@ -102,7 +101,7 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_object_initializer = true:suggestion
-dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
@@ -399,3 +398,9 @@ dotnet_diagnostic.CA1805.severity = suggestion
 dotnet_diagnostic.CA1825.severity = warning
 dotnet_diagnostic.CA1841.severity = warning
 dotnet_diagnostic.CA2016.severity = warning
+
+# IDE0032: Use auto property
+dotnet_diagnostic.IDE0032.severity = none
+
+# MSTEST0006: Avoid [ExpectedException]
+dotnet_diagnostic.MSTEST0006.severity = none

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Danylo Fitel
+Copyright (c) 2026 Danylo Fitel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-A library of C# core components that enhance the standard library. Supports .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, .NET 7.0, .NET 8.0, .NET 9.0.
+A library of C# core components that enhance the standard library. Supports .NET 8.0, .NET 9.0, .NET 10.0.
 
 * Source code: <https://github.com/danylofitel/LibSharp>.
 * NuGet package: <https://www.nuget.org/packages/LibSharp>.
@@ -22,7 +22,7 @@ LibSharp consists of the following namespaces:
 ```csharp
     using LibSharp.Common;
 
-    public static void CommonExamples(string stringParam, long longParam, object objectParam, CancellationToken cancellationToken)
+    public static async Task CommonExamples(string stringParam, long longParam, object objectParam, CancellationToken cancellationToken)
     {
         // Argument validation
         Argument.EqualTo(stringParam, "Hello world", nameof(stringParam));
@@ -35,7 +35,7 @@ LibSharp consists of the following namespaces:
 
         Argument.NotNull(stringParam, nameof(stringParam));
         Argument.NotNullOrEmpty(stringParam, nameof(stringParam));
-        Argument.IsNullOrWhiteSpace(stringParam, nameof(stringParam));
+        Argument.NotNullOrWhiteSpace(stringParam, nameof(stringParam));
 
         Argument.OfType(objectParam, typeof(List<string>), nameof(objectParam));
 
@@ -57,7 +57,10 @@ LibSharp consists of the following namespaces:
         int taskResult = await task.RunWithTimeout(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
 
         // Int extensions
-        bool converted = 200.TryConvertToEnum<HttpStatusCode>(out HttpStatusCode statusCode);
+        bool convertedFromInt = 200.TryConvertToEnum<HttpStatusCode>(out HttpStatusCode statusCode);
+
+        // String extensions (TryConvertToEnum)
+        bool convertedFromString = "OK".TryConvertToEnum<HttpStatusCode>(out HttpStatusCode statusCode2);
 
         // Regex extensions
         Regex regex = new Regex(pattern: "\\s+brown\\s+", options: RegexOptions.None, matchTimeout: TimeSpan.FromSeconds(1));
@@ -132,9 +135,9 @@ LibSharp consists of the following namespaces:
         // IEnumerable extensions
         List<List<int>> chunks = Enumerable.Range(0, 10).Chunk(20, item => item).ToList();  // [ [0, 1, 2, 3, 4, 5], [6, 7], [8, 9] ]
 
-        IEnumerable<int> enumerable = Enumerable.Range(100).Concat(Enumerable.Range(100)).ToList();
-        int firstIndex = enumerable.FirstIndexOf(51);
-        int lastIndex = enumerable.LastIndexOf(51);
+        IEnumerable<int> enumerable = Enumerable.Range(0, 100).Concat(Enumerable.Range(0, 100)).ToList();
+        int firstIndex = enumerable.FirstIndexOf(x => x == 51);
+        int lastIndex = enumerable.LastIndexOf(x => x == 51);
 
         int[] shuffled = enumerable.Shuffle();
 
@@ -149,7 +152,7 @@ LibSharp consists of the following namespaces:
         _ = minPq.Dequeue();    // 3
 
         // Max priority queue
-        MinPriorityQueue<int> maxPq = new MinPriorityQueue<int>();
+        MaxPriorityQueue<int> maxPq = new MaxPriorityQueue<int>();
         maxPq.Enqueue(2);
         maxPq.Enqueue(1);
         maxPq.Enqueue(3);
@@ -268,11 +271,11 @@ Note that `ValueCacheAsync` guarantees `LazyThreadSafetyMode.ExecutionAndPublica
         using ValueCacheAsync<int> cache = new ValueCacheAsync<int>(factory, TimeSpan.FromMilliseconds(1));
 
         bool hasValue = cache.HasValue;                                     // false
-        int value = await cache.GetValueAsync(factory, cancellationToken);  // factory invoked
+        int value = await cache.GetValueAsync(cancellationToken);           // factory invoked
         hasValue = cache.HasValue;                                          // true
 
         await Task.Delay(10);
-        value = await cache.GetValueAsync(factory, cancellationToken);      // factory invoked
+        value = await cache.GetValueAsync(cancellationToken);               // factory invoked
         hasValue = cache.HasValue;                                          // true
     }
 ```
@@ -299,12 +302,31 @@ Key-value caches allow to cache and automatically refresh multiple values within
     {
         using KeyValueCacheAsync<string, int> cache = new KeyValueCacheAsync<string, int>(factory, TimeSpan.FromMinutes(1));
 
-        KeyValueCache<string, int> cache = new KeyValueCache<string, int>(factory, TimeSpan.FromMinutes(1));
-
         int valueA = await cache.GetValueAsync("a", cancellationToken); // factory invoked for "a"
         int valueB = await cache.GetValueAsync("b", cancellationToken); // factory invoked for "b"
 
         valueA = await cache.GetValueAsync("a", cancellationToken);     // factory not invoked
         valueB = await cache.GetValueAsync("b", cancellationToken);     // factory not invoked
+    }
+```
+
+#### Proactive Async Cache
+
+`ProactiveAsyncCache` is an async cache that proactively refreshes its value in the background before it expires. It starts a background loop that re-fetches the value at a configurable interval. A pre-fetch offset allows the refresh to happen before the current value expires, ensuring callers always get a fresh value without waiting for the factory.
+
+```csharp
+    using LibSharp.Caching;
+
+    public static async Task ProactiveAsyncCacheExample(Func<CancellationToken, Task<int>> factory, CancellationToken cancellationToken)
+    {
+        await using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(
+            factory,
+            refreshInterval: TimeSpan.FromMinutes(5),
+            preFetchOffset: TimeSpan.FromSeconds(30));
+
+        bool hasValue = cache.HasValue;                                     // false (until first background fetch completes)
+        int value = await cache.GetValueAsync(cancellationToken);           // factory invoked if background fetch hasn't completed yet
+        hasValue = cache.HasValue;                                          // true
+        value = await cache.GetValueAsync(cancellationToken);               // returns cached value
     }
 ```

--- a/src/LibSharp/Caching/Initializer.cs
+++ b/src/LibSharp/Caching/Initializer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
 using System;
+using System.Threading;
+using LibSharp.Common;
 
 namespace LibSharp.Caching
 {
@@ -8,11 +10,17 @@ namespace LibSharp.Caching
     public class Initializer<T> : IInitializer<T>
     {
         /// <inheritdoc/>
-        public bool HasValue { get; private set; }
+        public bool HasValue
+        {
+            get => m_hasValue;
+            private set => m_hasValue = value;
+        }
 
         /// <inheritdoc/>
         public T GetValue(Func<T> factory)
         {
+            Argument.NotNull(factory, nameof(factory));
+
             if (!HasValue)
             {
                 lock (m_lock)
@@ -22,6 +30,8 @@ namespace LibSharp.Caching
                         m_instance = factory();
                         HasValue = true;
                     }
+
+                    return m_instance;
                 }
             }
 
@@ -29,6 +39,7 @@ namespace LibSharp.Caching
         }
 
         private readonly object m_lock = new object();
+        private volatile bool m_hasValue;
         private T m_instance;
     }
 }

--- a/src/LibSharp/Caching/InitializerAsyncExecutionAndPublication.cs
+++ b/src/LibSharp/Caching/InitializerAsyncExecutionAndPublication.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using LibSharp.Common;
 
 namespace LibSharp.Caching
 {
@@ -30,6 +31,8 @@ namespace LibSharp.Caching
         /// <inheritdoc/>
         public async Task<T> GetValueAsync(Func<CancellationToken, Task<T>> factory, CancellationToken cancellationToken = default)
         {
+            Argument.NotNull(factory, nameof(factory));
+
             if (m_isDisposed)
             {
                 throw new ObjectDisposedException(GetType().FullName);
@@ -46,6 +49,8 @@ namespace LibSharp.Caching
                         m_value = await factory(cancellationToken).ConfigureAwait(false);
                         m_hasValue = true;
                     }
+
+                    return m_value;
                 }
                 finally
                 {
@@ -71,15 +76,19 @@ namespace LibSharp.Caching
         {
             if (!m_isDisposed)
             {
-                m_semaphore.Dispose();
+                if (disposing)
+                {
+                    m_semaphore.Dispose();
+                }
+
                 m_isDisposed = true;
             }
         }
 
         private readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
 
-        private bool m_hasValue;
+        private volatile bool m_hasValue;
         private T m_value;
-        private bool m_isDisposed;
+        private volatile bool m_isDisposed;
     }
 }

--- a/src/LibSharp/Caching/KeyValueCache.cs
+++ b/src/LibSharp/Caching/KeyValueCache.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using LibSharp.Common;
 
 namespace LibSharp.Caching
@@ -11,6 +12,11 @@ namespace LibSharp.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type.</typeparam>
     /// <typeparam name="TValue">Value type.</typeparam>
+    /// <remarks>
+    /// Entries are never evicted from the cache.
+    /// This is by design for bounded key spaces.
+    /// Do not use with unbounded key spaces as memory will grow monotonically.
+    /// </remarks>
     public class KeyValueCache<TKey, TValue> : IKeyValueCache<TKey, TValue>
         where TKey : notnull
     {
@@ -81,9 +87,13 @@ namespace LibSharp.Caching
         {
             Argument.NotNull(key, nameof(key));
 
-            ValueCache<TValue> valueCache = m_cache.GetOrAdd(key, CreateValueCache);
+            Lazy<ValueCache<TValue>> lazyValueCache = m_cache.GetOrAdd(
+                key,
+                cacheKey => new Lazy<ValueCache<TValue>>(
+                    () => CreateValueCache(cacheKey),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
 
-            return valueCache.GetValue();
+            return lazyValueCache.Value.GetValue();
         }
 
         private ValueCache<TValue> CreateValueCache(TKey key)
@@ -100,7 +110,7 @@ namespace LibSharp.Caching
                 : new ValueCache<TValue>(() => m_createFactory(key), value => m_updateFactory(key, value), value => m_expirationFunction(key, value));
         }
 
-        private readonly ConcurrentDictionary<TKey, ValueCache<TValue>> m_cache = new ConcurrentDictionary<TKey, ValueCache<TValue>>();
+        private readonly ConcurrentDictionary<TKey, Lazy<ValueCache<TValue>>> m_cache = new ConcurrentDictionary<TKey, Lazy<ValueCache<TValue>>>();
 
         private readonly Func<TKey, TValue> m_createFactory;
         private readonly Func<TKey, TValue, TValue> m_updateFactory;

--- a/src/LibSharp/Caching/KeyValueCacheAsync.cs
+++ b/src/LibSharp/Caching/KeyValueCacheAsync.cs
@@ -13,6 +13,11 @@ namespace LibSharp.Caching
     /// </summary>
     /// <typeparam name="TKey">Key type.</typeparam>
     /// <typeparam name="TValue">Value type.</typeparam>
+    /// <remarks>
+    /// Entries are never evicted from the cache.
+    /// This is by design for bounded key spaces.
+    /// Do not use with unbounded key spaces as memory will grow monotonically.
+    /// </remarks>
     public class KeyValueCacheAsync<TKey, TValue> : IKeyValueCacheAsync<TKey, TValue>, IDisposable
         where TKey : notnull
     {
@@ -106,6 +111,12 @@ namespace LibSharp.Caching
                     () => CreateValueCache(cacheKey),
                     LazyThreadSafetyMode.ExecutionAndPublication));
 
+            // Re-check after GetOrAdd to avoid leaking entries added concurrently with Dispose.
+            if (m_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+
             /*
              * Now that the value cache for the key has been initialized with a single instance,
              * get the value cache from the Lazy wrapper.
@@ -141,6 +152,8 @@ namespace LibSharp.Caching
         {
             if (!m_isDisposed)
             {
+                m_isDisposed = true;
+
                 if (disposing)
                 {
                     foreach (Lazy<ValueCacheAsync<TValue>> cache in m_cache.Values)
@@ -150,9 +163,9 @@ namespace LibSharp.Caching
                             cache.Value.Dispose();
                         }
                     }
-                }
 
-                m_isDisposed = true;
+                    m_cache.Clear();
+                }
             }
         }
 
@@ -177,6 +190,6 @@ namespace LibSharp.Caching
         private readonly TimeSpan? m_timeToLive;
         private readonly Func<TKey, TValue, DateTime> m_expirationFunction;
 
-        private bool m_isDisposed;
+        private volatile bool m_isDisposed;
     }
 }

--- a/src/LibSharp/Caching/LazyAsyncExecutionAndPublication.cs
+++ b/src/LibSharp/Caching/LazyAsyncExecutionAndPublication.cs
@@ -77,6 +77,8 @@ namespace LibSharp.Caching
                         m_value = await m_factory(cancellationToken).ConfigureAwait(false);
                         m_hasValue = true;
                     }
+
+                    return m_value;
                 }
                 finally
                 {
@@ -102,7 +104,11 @@ namespace LibSharp.Caching
         {
             if (!m_isDisposed)
             {
-                m_semaphore.Dispose();
+                if (disposing)
+                {
+                    m_semaphore.Dispose();
+                }
+
                 m_isDisposed = true;
             }
         }
@@ -110,9 +116,9 @@ namespace LibSharp.Caching
         private readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
 
         private readonly Func<CancellationToken, Task<T>> m_factory;
-        private bool m_hasValue;
+        private volatile bool m_hasValue;
         private T m_value;
 
-        private bool m_isDisposed;
+        private volatile bool m_isDisposed;
     }
 }

--- a/src/LibSharp/Caching/ProactiveAsyncCache.cs
+++ b/src/LibSharp/Caching/ProactiveAsyncCache.cs
@@ -1,0 +1,183 @@
+// Copyright (c) LibSharp. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LibSharp.Common;
+
+namespace LibSharp.Caching;
+
+/// <summary>
+/// An async cache that proactively refreshes its value in the background before it expires.
+/// </summary>
+/// <typeparam name="T">Value type.</typeparam>
+public class ProactiveAsyncCache<T> : IValueCacheAsync<T>, IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProactiveAsyncCache{T}"/> class.
+    /// </summary>
+    /// <param name="valueFactory">The value factory.</param>
+    /// <param name="refreshInterval">The interval at which the cache should be refreshed.</param>
+    /// <param name="preFetchOffset">The offset before the refresh interval to pre-fetch the value.</param>
+    public ProactiveAsyncCache(
+        Func<CancellationToken, Task<T>> valueFactory,
+        TimeSpan refreshInterval,
+        TimeSpan preFetchOffset)
+    {
+        Argument.NotNull(valueFactory, nameof(valueFactory));
+        Argument.GreaterThan(refreshInterval, TimeSpan.Zero, nameof(refreshInterval));
+        Argument.GreaterThanOrEqualTo(preFetchOffset, TimeSpan.Zero, nameof(preFetchOffset));
+        Argument.LessThan(preFetchOffset, refreshInterval, nameof(preFetchOffset));
+
+        m_cts = new CancellationTokenSource();
+        m_semaphore = new SemaphoreSlim(1, 1);
+        m_fetchFunc = valueFactory;
+        m_refreshInterval = refreshInterval;
+        m_preFetchOffset = preFetchOffset;
+        m_backgroundTask = Task.Run(StartBackgroundRefresh);
+    }
+
+    /// <inheritdoc/>
+    public bool HasValue
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(m_isDisposed, this);
+
+            return m_snapshot is not null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public DateTime? Expiration
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(m_isDisposed, this);
+
+            return m_snapshot?.NextRefreshTime;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<T> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(m_isDisposed, this);
+
+        CacheSnapshot snapshot = m_snapshot;
+        if (snapshot is null || DateTime.UtcNow >= snapshot.NextRefreshTime)
+        {
+            await m_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                snapshot = m_snapshot;
+                if (snapshot is null || DateTime.UtcNow >= snapshot.NextRefreshTime)
+                {
+                    T value = await m_fetchFunc(cancellationToken).ConfigureAwait(false);
+                    snapshot = new CacheSnapshot(value, DateTime.UtcNow + m_refreshInterval);
+                    m_snapshot = snapshot;
+                }
+
+                return snapshot.Value;
+            }
+            finally
+            {
+                _ = m_semaphore.Release();
+            }
+        }
+
+        return snapshot.Value;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore().ConfigureAwait(false);
+        Dispose(false);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes of the cache.
+    /// </summary>
+    /// <param name="disposing">True if the method was called during disposal, false otherwise.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!m_isDisposed)
+        {
+            m_isDisposed = true;
+
+            if (disposing)
+            {
+                m_cts.Cancel();
+                m_backgroundTask.GetAwaiter().GetResult();
+                m_semaphore.Dispose();
+                m_cts.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Performs async disposal of the cache resources.
+    /// </summary>
+    /// <returns>A task representing the async dispose operation.</returns>
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+        if (!m_isDisposed)
+        {
+            m_isDisposed = true;
+
+            m_cts.Cancel();
+            await m_backgroundTask.ConfigureAwait(false);
+            m_semaphore.Dispose();
+            m_cts.Dispose();
+        }
+    }
+
+    private async Task StartBackgroundRefresh()
+    {
+        while (!m_cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(m_refreshInterval - m_preFetchOffset, m_cts.Token).ConfigureAwait(false);
+                await m_semaphore.WaitAsync(m_cts.Token).ConfigureAwait(false);
+                try
+                {
+                    T value = await m_fetchFunc(m_cts.Token).ConfigureAwait(false);
+                    m_snapshot = new CacheSnapshot(value, DateTime.UtcNow + m_refreshInterval);
+                }
+                finally
+                {
+                    _ = m_semaphore.Release();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                // Transient failure; will retry on next cycle
+            }
+        }
+    }
+
+    private readonly CancellationTokenSource m_cts;
+    private readonly SemaphoreSlim m_semaphore;
+    private readonly Func<CancellationToken, Task<T>> m_fetchFunc;
+    private readonly TimeSpan m_refreshInterval;
+    private readonly TimeSpan m_preFetchOffset;
+    private readonly Task m_backgroundTask;
+    private volatile CacheSnapshot m_snapshot;
+    private volatile bool m_isDisposed;
+
+    private sealed record CacheSnapshot(T Value, DateTime NextRefreshTime);
+}

--- a/src/LibSharp/Caching/ValueCache.cs
+++ b/src/LibSharp/Caching/ValueCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
 using System;
+using System.Threading;
 using LibSharp.Common;
 
 namespace LibSharp.Caching
@@ -91,6 +92,8 @@ namespace LibSharp.Caching
                     {
                         Refresh();
                     }
+
+                    return m_boxed.Value;
                 }
             }
 
@@ -99,7 +102,9 @@ namespace LibSharp.Caching
 
         private static DateTime GetExpiration(TimeSpan timeToLive)
         {
-            return timeToLive == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow.Add(timeToLive);
+            return timeToLive >= DateTime.MaxValue - DateTime.UtcNow
+                ? DateTime.MaxValue
+                : DateTime.UtcNow.Add(timeToLive);
         }
 
         private void Refresh()
@@ -125,6 +130,6 @@ namespace LibSharp.Caching
         private readonly Func<T, T> m_updateFactory;
         private readonly Func<T, DateTime> m_expirationFunction;
 
-        private ValueReference<T> m_boxed;
+        private volatile ValueReference<T> m_boxed;
     }
 }

--- a/src/LibSharp/Caching/ValueCacheAsync.cs
+++ b/src/LibSharp/Caching/ValueCacheAsync.cs
@@ -122,6 +122,8 @@ namespace LibSharp.Caching
                     {
                         await Refresh(cancellationToken).ConfigureAwait(false);
                     }
+
+                    return m_boxed.Value;
                 }
                 finally
                 {
@@ -160,7 +162,9 @@ namespace LibSharp.Caching
 
         private static DateTime GetExpiration(TimeSpan timeToLive)
         {
-            return timeToLive == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow.Add(timeToLive);
+            return timeToLive >= DateTime.MaxValue - DateTime.UtcNow
+                ? DateTime.MaxValue
+                : DateTime.UtcNow.Add(timeToLive);
         }
 
         private async Task Refresh(CancellationToken cancellationToken)
@@ -186,8 +190,8 @@ namespace LibSharp.Caching
         private readonly Func<T, CancellationToken, Task<T>> m_updateFactory;
         private readonly Func<T, DateTime> m_expirationFunction;
 
-        private ValueReference<T> m_boxed;
+        private volatile ValueReference<T> m_boxed;
 
-        private bool m_isDisposed;
+        private volatile bool m_isDisposed;
     }
 }

--- a/src/LibSharp/Collections/IEnumerableExtensions.cs
+++ b/src/LibSharp/Collections/IEnumerableExtensions.cs
@@ -124,14 +124,13 @@ namespace LibSharp.Collections
         {
             Argument.NotNull(source, nameof(source));
 
-            Random generator = new Random();
             TSource[] elements = source.ToArray();
 
             int count = elements.Length;
             while (count > 1)
             {
                 --count;
-                int k = generator.Next(count + 1);
+                int k = Random.Shared.Next(count + 1);
                 (elements[count], elements[k]) = (elements[k], elements[count]);
             }
 

--- a/src/LibSharp/Common/Argument.cs
+++ b/src/LibSharp/Common/Argument.cs
@@ -30,7 +30,7 @@ namespace LibSharp.Common
 
             if (!value.Equals(equalValue))
             {
-                throw new ArgumentException(name, $"{value} must be equal to {equalValue}.");
+                throw new ArgumentException($"{value} must be equal to {equalValue}.", name);
             }
         }
 
@@ -127,7 +127,7 @@ namespace LibSharp.Common
 
             if (value.Equals(notEqualValue))
             {
-                throw new ArgumentException(name, $"{value} must not be equal to {notEqualValue}.");
+                throw new ArgumentException($"{value} must not be equal to {notEqualValue}.", name);
             }
         }
 

--- a/src/LibSharp/Common/DateTimeExtensions.cs
+++ b/src/LibSharp/Common/DateTimeExtensions.cs
@@ -10,19 +10,13 @@ namespace LibSharp.Common
     public static class DateTimeExtensions
     {
         /// <summary>
-        /// The value of this constant is equivalent to 00:00:00.0000000 UTC, January 1, 1970, in the Gregorian calendar.
-        /// UnixEpoch defines the point in time when Unix time is equal to 0.
-        /// </summary>
-        public static DateTime UnixEpoch { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        /// <summary>
         /// Creates a DateTime from Epoch milliseconds.
         /// </summary>
         /// <param name="epochMilliseconds">Epoch milliseconds.</param>
         /// <returns>A DateTime value.</returns>
         public static DateTime FromEpochMilliseconds(this long epochMilliseconds)
         {
-            return UnixEpoch.AddMilliseconds(epochMilliseconds);
+            return DateTime.UnixEpoch.AddMilliseconds(epochMilliseconds);
         }
 
         /// <summary>
@@ -32,7 +26,7 @@ namespace LibSharp.Common
         /// <returns>A DateTime value.</returns>
         public static DateTime FromEpochSeconds(this long epochSeconds)
         {
-            return UnixEpoch.AddSeconds(epochSeconds);
+            return DateTime.UnixEpoch.AddSeconds(epochSeconds);
         }
 
         /// <summary>
@@ -42,7 +36,7 @@ namespace LibSharp.Common
         /// <returns>Epoch milliseconds.</returns>
         public static long ToEpochMilliseconds(this DateTime dateTime)
         {
-            TimeSpan epochTimeSpan = dateTime.Subtract(UnixEpoch);
+            TimeSpan epochTimeSpan = dateTime.Subtract(DateTime.UnixEpoch);
             return Convert.ToInt64(epochTimeSpan.TotalMilliseconds);
         }
 
@@ -53,7 +47,7 @@ namespace LibSharp.Common
         /// <returns>Epoch seconds.</returns>
         public static long ToEpochSeconds(this DateTime dateTime)
         {
-            TimeSpan epochTimeSpan = dateTime.Subtract(UnixEpoch);
+            TimeSpan epochTimeSpan = dateTime.Subtract(DateTime.UnixEpoch);
             return Convert.ToInt64(epochTimeSpan.TotalSeconds);
         }
     }

--- a/src/LibSharp/Common/StringExtensions.cs
+++ b/src/LibSharp/Common/StringExtensions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace LibSharp.Common
@@ -47,9 +50,32 @@ namespace LibSharp.Common
         {
             Argument.NotNull(input, nameof(input));
 
-            char[] characters = input.ToCharArray();
-            Array.Reverse(characters);
-            return new string(characters);
+            int[] characterIndexes = StringInfo.ParseCombiningCharacters(input);
+
+            Array.Reverse(characterIndexes);
+
+            IEnumerable<string> elements = characterIndexes.Select(i => StringInfo.GetNextTextElement(input, i));
+
+            return string.Concat(elements);
+        }
+
+        /// <summary>
+        /// Converts a string to an enum value if possible.
+        /// </summary>
+        /// <typeparam name="T">Enum type.</typeparam>
+        /// <param name="value">String value.</param>
+        /// <param name="result">Enum value.</param>
+        /// <returns>True if the value is defined and was successfully converted, false otherwise.</returns>
+        public static bool TryConvertToEnum<T>(this string value, out T result)
+            where T : struct, Enum
+        {
+            if (Enum.TryParse(value, out result) && Enum.IsDefined(typeof(T), result))
+            {
+                return true;
+            }
+
+            result = default;
+            return false;
         }
 
         /// <summary>

--- a/src/LibSharp/Common/XmlSerializationExtensions.cs
+++ b/src/LibSharp/Common/XmlSerializationExtensions.cs
@@ -22,7 +22,7 @@ namespace LibSharp.Common
         {
             Argument.NotNullOrWhiteSpace(xmlString, nameof(xmlString));
 
-            StringReader stringReader = new StringReader(xmlString);
+            using StringReader stringReader = new StringReader(xmlString);
             using XmlReader xmlReader = XmlReader.Create(stringReader, xmlReaderSettings ?? s_xmlReaderSettings);
             XmlSerializer serializer = new XmlSerializer(typeof(T));
             return (T)serializer.Deserialize(xmlReader);

--- a/src/LibSharp/GlobalSuppressions.cs
+++ b/src/LibSharp/GlobalSuppressions.cs
@@ -5,5 +5,5 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Priority queue interface.", Scope = "type", Target = "~T:LibSharp.Collections.IPriorityQueue`1")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Max priority queue implmenentation.", Scope = "type", Target = "~T:LibSharp.Collections.MaxPriorityQueue`1")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Min priority queue implmenentation.", Scope = "type", Target = "~T:LibSharp.Collections.MinPriorityQueue`1")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Max priority queue implementation.", Scope = "type", Target = "~T:LibSharp.Collections.MaxPriorityQueue`1")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "Min priority queue implementation.", Scope = "type", Target = "~T:LibSharp.Collections.MinPriorityQueue`1")]

--- a/src/LibSharp/LibSharp.csproj
+++ b/src/LibSharp/LibSharp.csproj
@@ -1,19 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>LibSharp</AssemblyName>
     <RootNamespace>LibSharp</RootNamespace>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageId>LibSharp</PackageId>
     <Title>LibSharp</Title>
-    <Version>1.1.6</Version>
+    <Version>2.0.0</Version>
     <Authors>Danylo Fitel</Authors>
-    <Copyright>Copyright (c) Danylo Fitel 2024</Copyright>
+    <Copyright>Copyright (c) Danylo Fitel 2026</Copyright>
     <Description>Extends the standard library with:
 - Async lazy (PublicationOnly and ExecutionAndPublication thread safety modes).
 - Sync and async in-memory value cache.
@@ -22,7 +24,8 @@
 - Argument validation methods.
 - Extension methods for collection interfaces.
 - Extension methods for standard library types like int, string, DateTime.</Description>
-    <PackageReleaseNotes>- 1.1.6: Added TryConvertToEnum extension method for int type.
+    <PackageReleaseNotes>- 2.0.0: Dropped support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, and .NET 7.0. Added support for .NET 10.0. Removed DateTimeExtensions.UnixEpoch. Added ProactiveAsyncCache. Added TryConvertToEnum extension method for string type. Bug fixes and thread safety improvements.
+- 1.1.6: Added TryConvertToEnum extension method for int type.
 - 1.1.5: Added Regex extension methods that handle regex timeouts. Added Func extension methods that run asynchronous operations with a timeout.
 - 1.1.4: Added support for .NET 9.0.
 - 1.1.3: Updated tags and description.
@@ -41,6 +44,10 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/LibSharp.UnitTests/Caching/ProactiveAsyncCacheUnitTests.cs
+++ b/test/LibSharp.UnitTests/Caching/ProactiveAsyncCacheUnitTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) LibSharp. All rights reserved.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using LibSharp.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibSharp.UnitTests.Caching
+{
+    [TestClass]
+    public class ProactiveAsyncCacheUnitTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_ThrowsOnNullFactory()
+        {
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(null, TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(10));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Constructor_ThrowsOnZeroRefreshInterval()
+        {
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.Zero, TimeSpan.Zero);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Constructor_ThrowsOnNegativePreFetchOffset()
+        {
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromMinutes(1), TimeSpan.FromSeconds(-1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Constructor_ThrowsWhenPreFetchOffsetExceedsRefreshInterval()
+        {
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2));
+        }
+
+        [TestMethod]
+        public void HasValue_ReturnsFalseBeforeFirstFetch()
+        {
+            // Arrange
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act & Assert
+            Assert.IsFalse(cache.HasValue);
+        }
+
+        [TestMethod]
+        public void Expiration_ReturnsNullBeforeFirstFetch()
+        {
+            // Arrange
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act & Assert
+            Assert.IsNull(cache.Expiration);
+        }
+
+        [TestMethod]
+        public async Task GetValueAsync_ReturnsValueFromFactory()
+        {
+            // Arrange
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act
+            int value = await cache.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(42, value);
+        }
+
+        [TestMethod]
+        public async Task GetValueAsync_ReturnsCachedValueOnSubsequentCalls()
+        {
+            // Arrange
+            int callCount = 0;
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(
+                _ =>
+                {
+                    int result = Interlocked.Increment(ref callCount);
+                    return Task.FromResult(result);
+                },
+                TimeSpan.FromHours(1),
+                TimeSpan.Zero);
+
+            // Act
+            int first = await cache.GetValueAsync().ConfigureAwait(false);
+            int second = await cache.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(1, first);
+            Assert.AreEqual(1, second);
+            Assert.AreEqual(1, callCount);
+        }
+
+        [TestMethod]
+        public async Task HasValue_ReturnsTrueAfterFetch()
+        {
+            // Arrange
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act
+            _ = await cache.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.IsTrue(cache.HasValue);
+        }
+
+        [TestMethod]
+        public async Task Expiration_ReturnsValueAfterFetch()
+        {
+            // Arrange
+            using ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act
+            _ = await cache.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.IsNotNull(cache.Expiration);
+            Assert.IsTrue(cache.Expiration > DateTime.UtcNow);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void HasValue_ThrowsWhenDisposed()
+        {
+            // Arrange
+            ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+            cache.Dispose();
+
+            // Act
+            _ = cache.HasValue;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public void Expiration_ThrowsWhenDisposed()
+        {
+            // Arrange
+            ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+            cache.Dispose();
+
+            // Act
+            _ = cache.Expiration;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ObjectDisposedException))]
+        public async Task GetValueAsync_ThrowsWhenDisposed()
+        {
+            // Arrange
+            ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+            cache.Dispose();
+
+            // Act
+            _ = await cache.GetValueAsync().ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task DisposeAsync_CanBeCalledSafely()
+        {
+            // Arrange
+            ProactiveAsyncCache<int> cache = new ProactiveAsyncCache<int>(_ => Task.FromResult(42), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act
+            await cache.DisposeAsync().ConfigureAwait(false);
+
+            // Assert — should not throw
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public async Task GetValueAsync_WithReferenceType_ReturnsValue()
+        {
+            // Arrange
+            using ProactiveAsyncCache<string> cache = new ProactiveAsyncCache<string>(_ => Task.FromResult("hello"), TimeSpan.FromHours(1), TimeSpan.Zero);
+
+            // Act
+            string value = await cache.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual("hello", value);
+        }
+    }
+}

--- a/test/LibSharp.UnitTests/Collections/IEnumerableExtensionsTests.cs
+++ b/test/LibSharp.UnitTests/Collections/IEnumerableExtensionsTests.cs
@@ -243,7 +243,7 @@ namespace LibSharp.UnitTests.Collections
         public void Shuffle_EmptyEnumerable()
         {
             // Act
-            int[] output = Enumerable.Empty<int>().Shuffle();
+            int[] output = IEnumerableExtensions.Shuffle(Enumerable.Empty<int>());
 
             // Assert
             Assert.AreEqual(0, output.Length);
@@ -256,7 +256,7 @@ namespace LibSharp.UnitTests.Collections
             List<int> input = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
             // Act
-            int[] output = input.Shuffle();
+            int[] output = IEnumerableExtensions.Shuffle(input);
 
             // Assert
             CollectionAssert.AreEquivalent(input, output);

--- a/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/MaxPriorityQueueUnitTests.cs
@@ -746,7 +746,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            int[] collection = Enumerable.Range(0, 100).Shuffle();
+            int[] collection = IEnumerableExtensions.Shuffle(Enumerable.Range(0, 100));
             MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(collection);
 
             // Act
@@ -764,7 +764,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetWeakEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            int[] collection = Enumerable.Range(0, 100).Shuffle();
+            int[] collection = IEnumerableExtensions.Shuffle(Enumerable.Range(0, 100));
             IEnumerable queue = new MaxPriorityQueue<int>(collection);
 
             // Act
@@ -783,7 +783,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_Current_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -803,7 +803,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_MoveNext_ReturnsFalse()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -824,7 +824,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_Reset_ResetsEnumerator()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -853,7 +853,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_Current_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -873,7 +873,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_MoveNext_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -893,7 +893,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_Reset_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -913,7 +913,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_Current_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())
@@ -933,7 +933,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_MoveNext_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())
@@ -953,7 +953,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_Reset_Throws()
         {
             // Arrange
-            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MaxPriorityQueue<int> queue = new MaxPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())

--- a/test/LibSharp.UnitTests/Collections/MinPriorityQueueUnitTests.cs
+++ b/test/LibSharp.UnitTests/Collections/MinPriorityQueueUnitTests.cs
@@ -746,7 +746,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            List<int> collection = Enumerable.Range(0, 100).Shuffle().ToList();
+            List<int> collection = IEnumerableExtensions.Shuffle(Enumerable.Range(0, 100)).ToList();
             MinPriorityQueue<int> queue = new MinPriorityQueue<int>(collection);
 
             // Act
@@ -764,7 +764,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetWeakEnumerator_NonEmptyQueue_IteratesThroughAllElements()
         {
             // Arrange
-            List<int> collection = Enumerable.Range(0, 100).Shuffle().ToList();
+            List<int> collection = IEnumerableExtensions.Shuffle(Enumerable.Range(0, 100)).ToList();
             IEnumerable queue = new MinPriorityQueue<int>(collection);
 
             // Act
@@ -783,7 +783,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_Current_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -803,7 +803,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_MoveNext_ReturnsFalse()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -824,7 +824,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterEnumeratingAllElements_Reset_ResetsEnumerator()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -853,7 +853,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_Current_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -873,7 +873,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_MoveNext_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -893,7 +893,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_QueueModifiedDuringEnumeration_Reset_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             using (IEnumerator<int> enumerator = queue.GetEnumerator())
             {
@@ -913,7 +913,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_Current_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())
@@ -933,7 +933,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_MoveNext_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())
@@ -953,7 +953,7 @@ namespace LibSharp.UnitTests.Collections
         public void GetEnumerator_AfterDisposing_Reset_Throws()
         {
             // Arrange
-            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(Enumerable.Range(0, 10).Shuffle());
+            MinPriorityQueue<int> queue = new MinPriorityQueue<int>(IEnumerableExtensions.Shuffle(Enumerable.Range(0, 10)));
 
             IEnumerator<int> enumerator;
             using (enumerator = queue.GetEnumerator())

--- a/test/LibSharp.UnitTests/Common/ArgumentUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/ArgumentUnitTests.cs
@@ -46,7 +46,7 @@ namespace LibSharp.UnitTests.Common
             Argument.EqualTo(double.Epsilon, double.Epsilon, "name");
             Argument.EqualTo('c', 'c', "name");
             Argument.EqualTo("value", "value", "name");
-            Argument.EqualTo(DateTimeExtensions.UnixEpoch, DateTimeExtensions.UnixEpoch, "name");
+            Argument.EqualTo(DateTime.UnixEpoch, DateTime.UnixEpoch, "name");
             Argument.EqualTo(Guid.Empty, Guid.Empty, "name");
             Argument.EqualTo(this, this, "name");
         }

--- a/test/LibSharp.UnitTests/Common/BoxUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/BoxUnitTests.cs
@@ -47,18 +47,18 @@ namespace LibSharp.UnitTests.Common
         public void ValueType_FromValue()
         {
             // Arrange
-            Box<DateTime> box = new Box<DateTime>(DateTimeExtensions.UnixEpoch);
+            Box<DateTime> box = new Box<DateTime>(DateTime.UnixEpoch);
 
             // Assert
             Assert.IsTrue(box.HasValue);
-            Assert.AreEqual(DateTimeExtensions.UnixEpoch, box.Value);
+            Assert.AreEqual(DateTime.UnixEpoch, box.Value);
         }
 
         [TestMethod]
         public void ValueType_FromValue_WhenCopied_RetainsState()
         {
             // Arrange
-            Box<DateTime> box = new Box<DateTime>(DateTimeExtensions.UnixEpoch);
+            Box<DateTime> box = new Box<DateTime>(DateTime.UnixEpoch);
 
             // Act
             Box<DateTime> copy = CopyBox(box);
@@ -198,7 +198,7 @@ namespace LibSharp.UnitTests.Common
             // Assert
             Assert.IsFalse(box.Equals((object)null));
             Assert.IsFalse(box.Equals(1));
-            Assert.IsFalse(box.Equals(DateTimeExtensions.UnixEpoch));
+            Assert.IsFalse(box.Equals(DateTime.UnixEpoch));
             Assert.IsFalse(box.Equals(new Box<object>(new object())));
             Assert.IsFalse(box.Equals(new Box<object>("boxed")));
             Assert.IsFalse(box.Equals((object)"boxed"));
@@ -217,7 +217,7 @@ namespace LibSharp.UnitTests.Common
             // Assert
             Assert.IsFalse(box.Equals((object)null));
             Assert.IsFalse(box.Equals(1));
-            Assert.IsFalse(box.Equals(DateTimeExtensions.UnixEpoch));
+            Assert.IsFalse(box.Equals(DateTime.UnixEpoch));
             Assert.IsFalse(box.Equals(new Box<object>(new object())));
             Assert.IsFalse(box.Equals(new Box<object>("boxed")));
 

--- a/test/LibSharp.UnitTests/Common/DateTimeExtensionsUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/DateTimeExtensionsUnitTests.cs
@@ -13,7 +13,7 @@ namespace LibSharp.UnitTests.Common
         public void FromEpochMilliseconds()
         {
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
-            long millisecondsSinceEpoch = (long)currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalMilliseconds;
+            long millisecondsSinceEpoch = (long)currentDate.Subtract(DateTime.UnixEpoch).TotalMilliseconds;
             DateTime convertedDateTime = millisecondsSinceEpoch.FromEpochMilliseconds();
 
             Assert.AreEqual(currentDate.Date, convertedDateTime.Date);
@@ -25,7 +25,7 @@ namespace LibSharp.UnitTests.Common
         public void FromEpochSeconds()
         {
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
-            long secondsSinceEpoch = (long)currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalSeconds;
+            long secondsSinceEpoch = (long)currentDate.Subtract(DateTime.UnixEpoch).TotalSeconds;
             DateTime convertedDateTime = secondsSinceEpoch.FromEpochSeconds();
 
             Assert.AreEqual(currentDate.Date, convertedDateTime.Date);
@@ -36,7 +36,7 @@ namespace LibSharp.UnitTests.Common
         [TestMethod]
         public void ToEpochMilliseconds()
         {
-            long fromEpoch = DateTimeExtensions.UnixEpoch.ToEpochMilliseconds();
+            long fromEpoch = DateTime.UnixEpoch.ToEpochMilliseconds();
             Assert.AreEqual(0, fromEpoch);
 
             long fromDayAfterEpoch = new DateTime(1970, 1, 2).ToEpochMilliseconds();
@@ -44,22 +44,22 @@ namespace LibSharp.UnitTests.Common
 
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
             currentDate = currentDate.AddMilliseconds(-currentDate.Millisecond);
-            long millisecondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalMilliseconds);
+            long millisecondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTime.UnixEpoch).TotalMilliseconds);
             Assert.AreEqual(currentDate.ToEpochMilliseconds(), millisecondsSinceEpoch);
         }
 
         [TestMethod]
         public void ToEpochSeconds()
         {
-            long fromEpoch = DateTimeExtensions.UnixEpoch.ToEpochSeconds();
+            long fromEpoch = DateTime.UnixEpoch.ToEpochSeconds();
             Assert.AreEqual(0, fromEpoch);
 
-            long fromDayAfterEpoch = DateTimeExtensions.UnixEpoch.AddDays(1).ToEpochSeconds();
+            long fromDayAfterEpoch = DateTime.UnixEpoch.AddDays(1).ToEpochSeconds();
             Assert.AreEqual(24 * 60 * 60, fromDayAfterEpoch);
 
             DateTime currentDate = new DateTime(2022, 2, 2, 2, 2, 2, DateTimeKind.Utc);
             currentDate = currentDate.AddMilliseconds(-currentDate.Millisecond);
-            long secondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTimeExtensions.UnixEpoch).TotalSeconds);
+            long secondsSinceEpoch = Convert.ToInt64(currentDate.Subtract(DateTime.UnixEpoch).TotalSeconds);
             Assert.AreEqual(currentDate.ToEpochSeconds(), secondsSinceEpoch);
         }
     }

--- a/test/LibSharp.UnitTests/Common/StringExtensionsUnitTests.cs
+++ b/test/LibSharp.UnitTests/Common/StringExtensionsUnitTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) LibSharp. All rights reserved.
 
+using System;
+using System.Net;
 using LibSharp.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -96,6 +98,86 @@ namespace LibSharp.UnitTests.Common
             Assert.AreEqual("aB", "aBc".Truncate(2));
             Assert.AreEqual("aBc", "aBc".Truncate(3));
             Assert.AreEqual("aBc", "aBc".Truncate(int.MaxValue));
+        }
+
+        [TestMethod]
+        public void TryConvertToEnum_HttpStatusCode()
+        {
+            // Arrange
+            HttpStatusCode result;
+
+            // Assert
+            Assert.IsFalse(((string)null).TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse(string.Empty.TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse(" ".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("abc".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("ok".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("notfound".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("-1".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("0".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("99".TryConvertToEnum<HttpStatusCode>(out _));
+            Assert.IsFalse("600".TryConvertToEnum<HttpStatusCode>(out _));
+
+            Assert.IsTrue("Continue".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.Continue, result);
+
+            Assert.IsTrue("SwitchingProtocols".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.SwitchingProtocols, result);
+
+            Assert.IsTrue("OK".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.OK, result);
+
+            Assert.IsTrue("BadRequest".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.BadRequest, result);
+
+            Assert.IsTrue("Unauthorized".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.Unauthorized, result);
+
+            Assert.IsTrue("Forbidden".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.Forbidden, result);
+
+            Assert.IsTrue("NotFound".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.NotFound, result);
+
+            Assert.IsTrue("InternalServerError".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.InternalServerError, result);
+
+            Assert.IsTrue("HttpVersionNotSupported".TryConvertToEnum<HttpStatusCode>(out result));
+            Assert.AreEqual(HttpStatusCode.HttpVersionNotSupported, result);
+        }
+
+        [TestMethod]
+        public void TryConvertToEnum_StringComparison()
+        {
+            // Arrange
+            StringComparison result;
+
+            // Assert
+            Assert.IsFalse(((string)null).TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse(string.Empty.TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse(" ".TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse("abc".TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse("ordinal".TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse("-1".TryConvertToEnum<StringComparison>(out _));
+            Assert.IsFalse("6".TryConvertToEnum<StringComparison>(out _));
+
+            Assert.IsTrue("CurrentCulture".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.CurrentCulture, result);
+
+            Assert.IsTrue("CurrentCultureIgnoreCase".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.CurrentCultureIgnoreCase, result);
+
+            Assert.IsTrue("InvariantCulture".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.InvariantCulture, result);
+
+            Assert.IsTrue("InvariantCultureIgnoreCase".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.InvariantCultureIgnoreCase, result);
+
+            Assert.IsTrue("Ordinal".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.Ordinal, result);
+
+            Assert.IsTrue("OrdinalIgnoreCase".TryConvertToEnum<StringComparison>(out result));
+            Assert.AreEqual(StringComparison.OrdinalIgnoreCase, result);
         }
     }
 }

--- a/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
+++ b/test/LibSharp.UnitTests/LibSharp.UnitTests.csproj
@@ -1,22 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>LibSharp.UnitTests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.11.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Dropped support for .NET Standard 2.0, .NET Standard 2.1, .NET 5.0, .NET 6.0, and .NET 7.0.
- Added support for .NET 10.0.
- Removed DateTimeExtensions.UnixEpoch.
- Added ProactiveAsyncCache.
- Added TryConvertToEnum extension method for string type.
- Bug fixes and thread safety improvements.